### PR TITLE
Implement subprocess-based bash_app and tests

### DIFF
--- a/tests/test_parsl_adapter_module.py
+++ b/tests/test_parsl_adapter_module.py
@@ -1,6 +1,40 @@
 import ast
 import warnings
-from parslet.compat.parsl_adapter import ParslToParsletTranslator
+import importlib.util
+import types
+import sys
+from pathlib import Path
+
+# Manually load the translator to avoid importing parslet.__init__
+ROOT = Path(__file__).resolve().parents[1]
+
+parslet_pkg = types.ModuleType("parslet")
+parslet_pkg.__path__ = [str(ROOT / "parslet")]
+sys.modules.setdefault("parslet", parslet_pkg)
+
+core_pkg = types.ModuleType("parslet.core")
+core_pkg.__path__ = [str(ROOT / "parslet" / "core")]
+sys.modules.setdefault("parslet.core", core_pkg)
+
+compat_pkg = types.ModuleType("parslet.compat")
+compat_pkg.__path__ = [str(ROOT / "parslet" / "compat")]
+sys.modules.setdefault("parslet.compat", compat_pkg)
+
+spec_task = importlib.util.spec_from_file_location(
+    "parslet.core.task", ROOT / "parslet" / "core" / "task.py"
+)
+task_module = importlib.util.module_from_spec(spec_task)
+sys.modules["parslet.core.task"] = task_module
+spec_task.loader.exec_module(task_module)
+
+spec_adapter = importlib.util.spec_from_file_location(
+    "parslet.compat.parsl_adapter", ROOT / "parslet" / "compat" / "parsl_adapter.py"
+)
+parsl_module = importlib.util.module_from_spec(spec_adapter)
+sys.modules["parslet.compat.parsl_adapter"] = parsl_module
+spec_adapter.loader.exec_module(parsl_module)
+
+ParslToParsletTranslator = parsl_module.ParslToParsletTranslator
 
 
 def test_parsl_translator_replaces_decorators():


### PR DESCRIPTION
## Summary
- Execute bash_app commands via `subprocess.run`, capturing stdout/stderr and raising errors on non-zero exit codes.
- Add targeted tests demonstrating successful command execution and proper error propagation.
- Introduce lightweight module loading in tests to avoid importing full package initialization.

## Testing
- `pytest tests/test_parsl_adapter_runtime.py tests/test_parsl_adapter_module.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689e19e1845883339447532a431b6453