### PR TITLE
Run bash commands via subprocess

### DIFF
--- a/tests/test_parsl_adapter_runtime.py
+++ b/tests/test_parsl_adapter_runtime.py
@@ -61,8 +61,7 @@ def test_bash_app_decorator_executes_with_parslet():
 
     fut = echo_message("hi")
     assert isinstance(fut, ParsletFuture)
-    result = fut.func(*fut.args, **fut.kwargs)
-    fut.set_result(result)
+    # Command executes immediately; result() returns stdout
     assert fut.result().strip() == "hi"
 
 
@@ -73,8 +72,9 @@ def test_bash_app_decorator_handles_errors():
 
     fut = fail()
     assert isinstance(fut, ParsletFuture)
+    # result() should raise the underlying CalledProcessError
     with pytest.raises(subprocess.CalledProcessError):
-        fut.func(*fut.args, **fut.kwargs)
+        fut.result()
 
 
 def test_dfk_stub_warns():


### PR DESCRIPTION
## Summary
- execute bash_app commands immediately with subprocess.run and wrap output in ParsletFuture
- test bash_app success path and error propagation

## Testing
- `pytest` *(fails: 19 errors during collection)*
- `pytest tests/test_parsl_adapter_module.py tests/test_parsl_adapter_runtime.py`

------
https://chatgpt.com/codex/tasks/task_e_689f91990e548333a492629fec825df0