### PR TITLE
Add Dask bridge for executing Parslet DAGs

### DIFF
--- a/parslet/core/__init__.py
+++ b/parslet/core/__init__.py
@@ -39,6 +39,7 @@ except Exception:
     __version__ = "0.0.0"
 from .scheduler import AdaptiveScheduler
 from .parsl_bridge import convert_task_to_parsl, execute_with_parsl
+from .dask_bridge import execute_with_dask
 from .dag_io import export_dag_to_json, import_dag_from_json
 
 # Placeholder for imports from .exporter module (once implemented)
@@ -63,6 +64,7 @@ __all__ = [
     "AdaptiveScheduler",
     "convert_task_to_parsl",
     "execute_with_parsl",
+    "execute_with_dask",
     "set_allow_redefine",
     "export_dag_to_json",
     "import_dag_from_json",

--- a/parslet/core/dask_bridge.py
+++ b/parslet/core/dask_bridge.py
@@ -1,0 +1,87 @@
+"""Dask compatibility helpers for Parslet."""
+
+from __future__ import annotations
+
+from typing import List, Dict, Any, Optional, Union
+
+from .dag import DAG
+from .task import ParsletFuture
+
+
+def execute_with_dask(
+    entry_futures: List[ParsletFuture],
+    scheduler: Optional[Union[str, Any]] = None,
+) -> List[Any]:
+    """Execute a Parslet workflow using Dask.
+
+    Parameters
+    ----------
+    entry_futures:
+        Terminal futures from the workflow's ``main()`` function.
+    scheduler:
+        Optional scheduler specification passed to :func:`dask.compute`.
+        This may be a string such as ``"threads"`` or ``"processes"`` or
+        a ``dask.distributed.Client`` instance.  If ``None`` a threaded
+        scheduler is used.
+
+    Examples
+    --------
+    >>> from parslet.core import parslet_task
+    >>> from parslet.core.dask_bridge import execute_with_dask
+    >>> @parslet_task
+    ... def inc(x):
+    ...     return x + 1
+    >>> futures = [inc(1)]
+    >>> execute_with_dask(futures)
+    [2]
+    """
+    try:
+        from dask import delayed, compute
+
+        try:
+            from dask.distributed import Client
+        except Exception:  # pragma: no cover - distributed optional
+            Client = None  # type: ignore
+    except Exception as exc:  # pragma: no cover - dask not installed
+        raise ImportError(
+            "Dask must be installed to run a Parslet workflow via Dask."
+        ) from exc
+
+    dag = DAG()
+    dag.build_dag(entry_futures)
+    dag.validate_dag()
+
+    order = dag.get_execution_order()
+    dask_futures: Dict[str, Any] = {}
+
+    for task_id in order:
+        pf = dag.get_task_future(task_id)
+        dask_task = delayed(pf.func)
+
+        resolved_args = [
+            dask_futures[a.task_id] if isinstance(a, ParsletFuture) else a
+            for a in pf.args
+        ]
+        resolved_kwargs = {
+            k: dask_futures[v.task_id] if isinstance(v, ParsletFuture) else v
+            for k, v in pf.kwargs.items()
+        }
+
+        dask_futures[task_id] = dask_task(*resolved_args, **resolved_kwargs)
+
+    entry_tasks = [dask_futures[f.task_id] for f in entry_futures]
+
+    if scheduler is None:
+        scheduler = "threads"
+
+    if (
+        "Client" in locals()
+        and Client is not None
+        and isinstance(scheduler, Client)
+    ):
+        futures = [scheduler.compute(t) for t in entry_tasks]
+        results = scheduler.gather(futures)
+    else:
+        results = compute(*entry_tasks, scheduler=scheduler)
+
+    return list(results)

--- a/tests/test_dask_bridge.py
+++ b/tests/test_dask_bridge.py
@@ -1,0 +1,73 @@
+import importlib.util
+import types
+import sys
+from pathlib import Path
+import pytest
+
+pytest.importorskip("dask")
+
+project_root = Path(__file__).resolve().parents[1]
+
+# Create minimal 'parslet' and 'parslet.core' packages to avoid executing
+# the package ``__init__`` (which depends on heavy runtime components).
+parslet_pkg = types.ModuleType("parslet")
+parslet_pkg.__path__ = [str(project_root / "parslet")]
+sys.modules.setdefault("parslet", parslet_pkg)
+
+core_pkg = types.ModuleType("parslet.core")
+core_pkg.__path__ = [str(project_root / "parslet/core")]
+sys.modules.setdefault("parslet.core", core_pkg)
+
+task_spec = importlib.util.spec_from_file_location(
+    "parslet.core.task", project_root / "parslet/core/task.py"
+)
+task_mod = importlib.util.module_from_spec(task_spec)
+task_spec.loader.exec_module(task_mod)
+sys.modules["parslet.core.task"] = task_mod
+setattr(core_pkg, "task", task_mod)
+
+bridge_spec = importlib.util.spec_from_file_location(
+    "parslet.core.dask_bridge", project_root / "parslet/core/dask_bridge.py"
+)
+bridge_mod = importlib.util.module_from_spec(bridge_spec)
+bridge_spec.loader.exec_module(bridge_mod)
+sys.modules["parslet.core.dask_bridge"] = bridge_mod
+setattr(core_pkg, "dask_bridge", bridge_mod)
+
+parslet_task = task_mod.parslet_task
+execute_with_dask = bridge_mod.execute_with_dask
+
+
+def test_execute_with_dask_threads():
+    @parslet_task
+    def one():
+        return 1
+
+    @parslet_task
+    def add_one(x):
+        return x + 1
+
+    futures = [add_one(one())]
+    results = execute_with_dask(futures)
+    assert results == [2]
+
+
+def test_execute_with_dask_client():
+    dask = pytest.importorskip("dask.distributed")
+
+    @parslet_task
+    def one():
+        return 1
+
+    @parslet_task
+    def add_one(x):
+        return x + 1
+
+    futures = [add_one(one())]
+
+    client = dask.Client(processes=False, n_workers=1, threads_per_worker=1)
+    try:
+        results = execute_with_dask(futures, scheduler=client)
+        assert results == [2]
+    finally:
+        client.close()


### PR DESCRIPTION
## Summary
- Implement `execute_with_dask` to run Parslet workflows on Dask schedulers
- Expose new Dask bridge in `parslet.core`
- Add tests verifying execution on thread and distributed Dask schedulers

## Testing
- `pytest tests/test_dask_bridge.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0cdf0cb9c833394045fedc1eda7c6