### PR TITLE
Add remote flag for hybrid tasks

### DIFF
--- a/docs/hybrid_orchestration.md
+++ b/docs/hybrid_orchestration.md
@@ -10,7 +10,9 @@ Parslet lets you create a single recipe where some tasks run locally on your dev
 
 ### How Does It Work?
 
-We have a special helper tool called `execute_hybrid`. You just give it your list of tasks and tell it the names of the ones you want to send to the "fast oven" (Parsl).
+We have a special helper tool called `execute_hybrid`. You just mark which
+tasks should use the "fast oven" (Parsl) by decorating them with
+`remote=True` and then run your workflow.
 
 Here’s what that looks like:
 
@@ -24,7 +26,7 @@ def chop_veggies():
     return 1
 
 # This is a bigger task we want to send to the powerful computer.
-@parslet_task
+@parslet_task(remote=True)
 def bake_pizza(ingredient):
     # This part of the code will actually run on the remote machine!
     print("Baking the pizza in the super-fast oven!")
@@ -35,11 +37,9 @@ if __name__ == "__main__":
     veggies_iou = chop_veggies()
     pizza_iou = bake_pizza(veggies_iou)
 
-    # ...but when we run it, we tell execute_hybrid which task is the "remote" one.
-    results = execute_hybrid(
-        [pizza_iou],
-        remote_tasks=["bake_pizza"] # <-- The magic instruction!
-    )
+    # ...and when we run it, `execute_hybrid` automatically sends
+    # the remote task to Parsl.
+    results = execute_hybrid([pizza_iou])
 
     print(f"The final result is: {results}")
 ```

--- a/parslet/core/runner.py
+++ b/parslet/core/runner.py
@@ -1,23 +1,23 @@
-import time
 import hashlib
-from concurrent.futures import ThreadPoolExecutor, Future as ExecutorFuture
-from typing import Optional, Dict, List, Any, Tuple
 import logging
 import socket
+import time
+from concurrent.futures import Future as ExecutorFuture
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-
-from .dag import DAG, DAGCycleError
-from .task import ParsletFuture
-from .scheduler import AdaptiveScheduler
-from ..utils.resource_utils import get_available_ram_mb
-from ..utils.diagnostics import find_free_port
-from ..utils.network_utils import is_network_available, is_vpn_active
-from ..utils.checkpointing import CheckpointManager
-from ..utils.resource_utils import get_battery_level
+from typing import Any, Dict, List, Optional, Tuple
 
 # Absolute import avoids issues when ``parslet`` is imported under
 # an alternative package name (e.g. ``Parslet`` during pytest collection).
 from parslet.security.defcon import Defcon
+
+from ..utils.checkpointing import CheckpointManager
+from ..utils.diagnostics import find_free_port
+from ..utils.network_utils import is_network_available, is_vpn_active
+from ..utils.resource_utils import get_available_ram_mb, get_battery_level
+from .dag import DAG, DAGCycleError
+from .scheduler import AdaptiveScheduler
+from .task import ParsletFuture
 
 
 class UpstreamTaskFailedError(RuntimeError):
@@ -163,9 +163,7 @@ class DAGRunner:
         self.failsafe_mode = failsafe_mode
         self.fallback_active = False
         user_specified_max_workers = max_workers
-        self.signature_file = (
-            Path(signature_file) if signature_file else None
-        )
+        self.signature_file = Path(signature_file) if signature_file else None
         self._tamper_check = (
             Defcon.tamper_guard(Path(p) for p in watch_files)
             if watch_files
@@ -296,7 +294,7 @@ class DAGRunner:
                     resolved_args.append(
                         None
                     )  # Append a placeholder; task won't run if
-                       # first_exception is set
+                    # first_exception is set
             else:
                 resolved_args.append(arg)
 
@@ -382,17 +380,13 @@ class DAGRunner:
                 f"during execution: {type(e).__name__}: {e}",
                 exc_info=True,
             )
-            # Provide a generic diagnostic hint to the user.
             diagnostic_msg = (
                 f"Task '{task_id}' ({parslet_future.func.__name__}) failed. "
-                "Some things to check:
-"
+                "Some things to check:\n"
                 "            - Are input files/data correct and accessible "
-                "for this task?
-"
+                "for this task?\n"
                 "            - Are there issues with external services or "
-                "resources it depends on?
-"
+                "resources it depends on?\n"
                 "            - Review the task's own logs or the error "
                 "message above for specific details."
             )

--- a/parslet/hybrid/executor.py
+++ b/parslet/hybrid/executor.py
@@ -7,7 +7,7 @@ starting point for more advanced federated orchestration.
 
 from __future__ import annotations
 
-from typing import Iterable, List, Dict, Any
+from typing import Any, Dict, List
 
 from ..core import DAG, ParsletFuture
 from ..core.parsl_bridge import convert_task_to_parsl
@@ -15,17 +15,17 @@ from ..core.parsl_bridge import convert_task_to_parsl
 
 def execute_hybrid(
     entry_futures: List[ParsletFuture],
-    remote_tasks: Iterable[str],
     parsl_config: Any | None = None,
 ) -> List[Any]:
     """Execute a workflow mixing local and Parsl-backed tasks.
+
+    Tasks are automatically routed to the remote Parsl backend when they
+    are defined with ``@parslet_task(remote=True)``.
 
     Parameters
     ----------
     entry_futures:
         List of terminal futures defining the workflow.
-    remote_tasks:
-        Iterable of function names that should run via Parsl.
     parsl_config:
         Optional Parsl ``Config`` object for remote execution.
 
@@ -66,7 +66,7 @@ def execute_hybrid(
             for k, v in pf.kwargs.items()
         }
 
-        if pf.func.__name__ in remote_tasks:
+        if getattr(pf.func, "_parslet_remote", False):
             parsl_app = convert_task_to_parsl(pf.func)
             results[task_id] = parsl_app(
                 *resolved_args, **resolved_kwargs

--- a/parslet/security/defcon.py
+++ b/parslet/security/defcon.py
@@ -4,7 +4,7 @@ import ast
 import hashlib
 import logging
 from pathlib import Path
-from typing import Iterable
+from typing import Callable, Iterable
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ class Defcon:
         return hashlib.sha256(sig.encode()).hexdigest() == dag_hash
 
     @staticmethod
-    def tamper_guard(watched: Iterable[Path]) -> bool:
+    def tamper_guard(watched: Iterable[Path]) -> Callable[[], bool]:
         """DEFCON3: ensure files unchanged."""
         hashes = {
             p: hashlib.sha256(p.read_bytes()).hexdigest() for p in watched

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -1,9 +1,9 @@
-import types
 import sys
+import types
 
 import pytest
 
-from parslet.core import parslet_task
+from parslet.core.task import parslet_task
 from parslet.hybrid.executor import execute_hybrid
 
 
@@ -90,10 +90,10 @@ def test_execute_hybrid_mixes_local_and_remote(stub_parsl):
     def one():
         return 1
 
-    @parslet_task
+    @parslet_task(remote=True)
     def add_one(x):
         return x + 1
 
-    results = execute_hybrid([add_one(one())], remote_tasks=["add_one"])
+    results = execute_hybrid([add_one(one())])
     parsl.dfk().cleanup()
     assert results == [2]


### PR DESCRIPTION
## Summary
- allow tasks to declare `remote=True` metadata
- route hybrid execution based on task metadata
- document remote task usage and add hybrid test

## Testing
- `SKIP=pytest pre-commit run --files parslet/core/task.py parslet/hybrid/executor.py parslet/core/runner.py parslet/security/defcon.py docs/hybrid_orchestration.md`
- `pre-commit run --files tests/test_hybrid.py`
- `pytest tests/test_hybrid.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1a199024c8333957d2ba10844c889