### PR TITLE
Fix flake8 line length issues

### DIFF
--- a/parslet/compat/dask_adapter.py
+++ b/parslet/compat/dask_adapter.py
@@ -67,7 +67,9 @@ class DaskToParsletTranslator(ast.NodeTransformer):
             return self.visit(node.func.value)
 
         # ``dask.delayed(func)(...)`` pattern
-        if isinstance(node.func, ast.Call) and self._is_delayed(node.func.func):
+        if isinstance(node.func, ast.Call) and self._is_delayed(
+            node.func.func
+        ):
             inner = node.func
             node.func = ast.Call(
                 func=ast.Name(id="parslet_task", ctx=ast.Load()),

--- a/parslet/core/dag.py
+++ b/parslet/core/dag.py
@@ -148,7 +148,8 @@ class DAG:
 
             visited_futures_for_processing.add(current_future.task_id)
 
-            # Ensure the current future is registered as a task and a graph node.
+            # Ensure the current future is registered as a task
+            # and a graph node.
             if current_future.task_id not in self.tasks:
                 self.graph.add_node(
                     current_future.task_id, future_obj=current_future
@@ -378,8 +379,10 @@ class DAG:
         """
         Saves a PNG visualization of the DAG to the specified filepath.
 
-        This method uses the `save_dag_to_png` utility from the exporter module.
-        It handles potential errors gracefully by logging them without crashing.
+        This method uses the `save_dag_to_png` utility from the exporter
+        module.
+        It handles potential errors gracefully by logging them without
+        crashing.
 
         Args:
             filepath (str): The path where the PNG image will be saved.

--- a/tests/test_dask_adapter_module.py
+++ b/tests/test_dask_adapter_module.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 project_root = Path(__file__).resolve().parents[1]
 
-# Create minimal 'parslet' and 'parslet.core' packages to satisfy relative imports
+# Create minimal 'parslet' and 'parslet.core' packages
+# to satisfy relative imports
 parslet_pkg = types.ModuleType("parslet")
 parslet_pkg.__path__ = [str(project_root / "parslet")]
 sys.modules.setdefault("parslet", parslet_pkg)

--- a/tests/test_parsl_adapter_module.py
+++ b/tests/test_parsl_adapter_module.py
@@ -28,7 +28,8 @@ sys.modules["parslet.core.task"] = task_module
 spec_task.loader.exec_module(task_module)
 
 spec_adapter = importlib.util.spec_from_file_location(
-    "parslet.compat.parsl_adapter", ROOT / "parslet" / "compat" / "parsl_adapter.py"
+    "parslet.compat.parsl_adapter",
+    ROOT / "parslet" / "compat" / "parsl_adapter.py",
 )
 parsl_module = importlib.util.module_from_spec(spec_adapter)
 sys.modules["parslet.compat.parsl_adapter"] = parsl_module

--- a/tests/test_parsl_adapter_runtime.py
+++ b/tests/test_parsl_adapter_runtime.py
@@ -34,7 +34,8 @@ ParsletFuture = task_module.ParsletFuture
 
 # Load parsl_adapter module
 spec_adapter = importlib.util.spec_from_file_location(
-    "parslet.compat.parsl_adapter", ROOT / "parslet" / "compat" / "parsl_adapter.py"
+    "parslet.compat.parsl_adapter",
+    ROOT / "parslet" / "compat" / "parsl_adapter.py",
 )
 parsl = importlib.util.module_from_spec(spec_adapter)
 sys.modules["parslet.compat.parsl_adapter"] = parsl


### PR DESCRIPTION
## Summary
- wrap long lines to conform to flake8's 79-character limit
- adjust test helpers for flake8 line length

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1b65d796483338b62675e43c1a1d4