### PR TITLE
Harden Defcon offline security

### DIFF
--- a/tests/test_defcon.py
+++ b/tests/test_defcon.py
@@ -1,4 +1,6 @@
+import hashlib
 from pathlib import Path
+
 from parslet.security.defcon import Defcon
 
 
@@ -18,3 +20,18 @@ def test_tamper_guard_detection(tmp_path):
     assert guard()
     file.write_text("changed")
     assert not guard()
+
+
+def test_verify_chain(tmp_path):
+    sig = tmp_path / "sig.txt"
+    payload = "payload"
+    dag_hash = hashlib.sha256(payload.encode()).hexdigest()
+
+    sig.write_text(payload)
+    assert Defcon.verify_chain(dag_hash, sig)
+
+    sig.write_text("tampered")
+    assert not Defcon.verify_chain(dag_hash, sig)
+
+    sig.unlink()
+    assert Defcon.verify_chain(dag_hash, sig)


### PR DESCRIPTION
## Summary
- optimize Defcon scanner and keep guard data local for offline use
- use constant-time comparison for DAG verification
- add coverage for verify_chain behavior

## Testing
- `pytest tests/test_defcon.py`

------
https://chatgpt.com/codex/tasks/task_e_68a1c809baec8333924bee0f1ba27faf