### PR TITLE
docs(api): define public surface & architecture; tighten all

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,15 @@
+# Parslet Architecture
+
+Parslet's runtime flows through a small set of primitives:
+
+```
+tasks -> futures -> DAG -> Runner -> Executor
+```
+
+1. `parslet_task` wraps Python callables and registers **tasks**.
+2. Calling a task returns a `ParsletFuture` placeholder for its result.
+3. A `DAG` links futures into a dependency graph.
+4. `DAGRunner` walks the graph and drives an underlying **executor**.
+
+The public API is intentionally tiny:
+`parslet_task`, `ParsletFuture`, `DAG`, and `DAGRunner`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,9 @@
+# Basic Usage
+
+Import the core symbols directly from the package:
+
+```python
+from parslet import parslet_task, DAG, DAGRunner, ParsletFuture
+```
+
+These four names form Parslet's stable public API.

--- a/parslet/__init__.py
+++ b/parslet/__init__.py
@@ -1,21 +1,11 @@
-"""Parslet subpackage."""
+"""Public Parslet API surface.
 
-from .core import (
-    parslet_task,
-    ParsletFuture,
-    DAG,
-    DAGCycleError,
-    DAGRunner,
-    UpstreamTaskFailedError,
-    BatteryLevelLowError,
-    AdaptiveScheduler,
-    convert_task_to_parsl,
-    execute_with_parsl,
-    set_allow_redefine,
-    export_dag_to_json,
-    import_dag_from_json,
-)
-from .hybrid import execute_hybrid, FileRelay
+Only a small set of names is re-exported here to keep the package's public
+interface compact and easy to learn.  Everything else remains available under
+``parslet.core`` or other subpackages.
+"""
+
+from .core import DAG, DAGRunner, ParsletFuture, parslet_task
 
 try:
     from importlib.metadata import version as _pkg_version
@@ -27,20 +17,4 @@ try:
 except Exception:
     __version__ = "0.0.0"
 
-__all__ = [
-    "parslet_task",
-    "ParsletFuture",
-    "DAG",
-    "DAGCycleError",
-    "DAGRunner",
-    "UpstreamTaskFailedError",
-    "BatteryLevelLowError",
-    "AdaptiveScheduler",
-    "convert_task_to_parsl",
-    "execute_with_parsl",
-    "set_allow_redefine",
-    "export_dag_to_json",
-    "import_dag_from_json",
-    "execute_hybrid",
-    "FileRelay",
-]
+__all__ = ["parslet_task", "ParsletFuture", "DAG", "DAGRunner"]

--- a/parslet/core/__init__.py
+++ b/parslet/core/__init__.py
@@ -1,14 +1,23 @@
-"""Public exports for Parslet core primitives."""
+"""Public exports for Parslet core primitives.
+
+This module defines the long-term stable API surface of ``parslet.core``.
+"""
 
 from importlib import metadata
 
 from .dag import DAG, DAGCycleError  # noqa: F401
-from .dag_io import export_dag_to_json, import_dag_from_json  # noqa: F401
-from .parsl_bridge import convert_task_to_parsl, execute_with_parsl  # noqa: F401
-from .runner import (
-    BatteryLevelLowError,  # noqa: F401
+from .dag_io import (  # noqa: F401
+    export_dag_to_json,
+    import_dag_from_json,
+)
+from .parsl_bridge import (  # noqa: F401
+    convert_task_to_parsl,
+    execute_with_parsl,
+)
+from .runner import (  # noqa: F401
+    BatteryLevelLowError,
     DAGRunner,
-    UpstreamTaskFailedError,  # noqa: F401
+    UpstreamTaskFailedError,
 )
 from .scheduler import AdaptiveScheduler  # noqa: F401
 from .task import ParsletFuture, parslet_task, set_allow_redefine  # noqa: F401

--- a/parslet/core/dag_io.py
+++ b/parslet/core/dag_io.py
@@ -1,9 +1,17 @@
+"""JSON serialization helpers for Parslet DAGs.
+
+Public API: :func:`export_dag_to_json` and :func:`import_dag_from_json`.
+"""
+
 import json
 import importlib
 from typing import Any, Dict, List
 
 from .dag import DAG
 from .task import ParsletFuture
+
+
+__all__ = ["export_dag_to_json", "import_dag_from_json"]
 
 
 def _serialize_arg(arg: Any) -> Any:
@@ -53,24 +61,17 @@ def import_dag_from_json(path: str) -> DAG:
         func = getattr(module, t["func_name"])
         if hasattr(func, "_parslet_original_func"):
             func = getattr(func, "_parslet_original_func")
-        future = ParsletFuture(
-            task_id=t["task_id"], func=func, args=(), kwargs={}
-        )
+        future = ParsletFuture(task_id=t["task_id"], func=func, args=(), kwargs={})
         task_map[t["task_id"]] = future
     # Second pass: assign args
     for t in tasks_data:
         future = task_map[t["task_id"]]
-        future.args = tuple(
-            _deserialize_arg(a, task_map) for a in t.get("args", [])
-        )
+        future.args = tuple(_deserialize_arg(a, task_map) for a in t.get("args", []))
         future.kwargs = {
-            k: _deserialize_arg(v, task_map)
-            for k, v in t.get("kwargs", {}).items()
+            k: _deserialize_arg(v, task_map) for k, v in t.get("kwargs", {}).items()
         }
     dag = DAG()
-    dag.graph.add_nodes_from(
-        (tid, {"future_obj": f}) for tid, f in task_map.items()
-    )
+    dag.graph.add_nodes_from((tid, {"future_obj": f}) for tid, f in task_map.items())
     dag.tasks = task_map
     for t in tasks_data:
         for dep in t.get("dependencies", []):

--- a/parslet/core/dask_bridge.py
+++ b/parslet/core/dask_bridge.py
@@ -1,4 +1,7 @@
-"""Dask compatibility helpers for Parslet."""
+"""Dask compatibility helpers for Parslet.
+
+Public API: :func:`execute_with_dask` to run a workflow via Dask.
+"""
 
 from __future__ import annotations
 
@@ -6,6 +9,9 @@ from typing import List, Dict, Any, Optional, Union
 
 from .dag import DAG
 from .task import ParsletFuture
+
+
+__all__ = ["execute_with_dask"]
 
 
 def execute_with_dask(
@@ -74,11 +80,7 @@ def execute_with_dask(
     if scheduler is None:
         scheduler = "threads"
 
-    if (
-        "Client" in locals()
-        and Client is not None
-        and isinstance(scheduler, Client)
-    ):
+    if "Client" in locals() and Client is not None and isinstance(scheduler, Client):
         futures = [scheduler.compute(t) for t in entry_tasks]
         results = scheduler.gather(futures)
     else:

--- a/parslet/core/exporter.py
+++ b/parslet/core/exporter.py
@@ -1,8 +1,22 @@
+"""Visualization and export utilities for Parslet DAGs.
+
+Public API: :func:`dag_to_pydot`, :func:`dag_to_dot_string`,
+``save_dag_to_png`` and related exceptions.
+"""
+
 import logging
 import networkx as nx
 from typing import TYPE_CHECKING, Optional
 
 logger = logging.getLogger(__name__)
+
+__all__ = [
+    "dag_to_pydot",
+    "dag_to_dot_string",
+    "save_dag_to_png",
+    "PydotImportError",
+    "GraphvizExecutableNotFoundError",
+]
 
 if TYPE_CHECKING:
     from .dag import (
@@ -128,12 +142,8 @@ def dag_to_dot_string(dag: "DAG") -> str:
         RuntimeError: If conversion to the `pydot.Dot` object fails
                       (propagated).
     """
-    pydot_graph = dag_to_pydot(
-        dag
-    )  # This will raise if pydot is not available.
-    if (
-        pydot_graph is None
-    ):  # Should not happen if PydotImportError is raised correctly
+    pydot_graph = dag_to_pydot(dag)  # This will raise if pydot is not available.
+    if pydot_graph is None:  # Should not happen if PydotImportError is raised correctly
         raise RuntimeError(
             "pydot graph generation failed unexpectedly, returning None."
         )
@@ -162,9 +172,7 @@ def save_dag_to_png(dag: "DAG", output_path: str) -> None:
                       such as file permission issues or unexpected `pydot`
                       errors.
     """
-    pydot_graph = dag_to_pydot(
-        dag
-    )  # Handles pydot import and initial conversion.
+    pydot_graph = dag_to_pydot(dag)  # Handles pydot import and initial conversion.
     if pydot_graph is None:  # Defensive check
         raise RuntimeError(
             "pydot graph generation failed unexpectedly, returning None, "
@@ -230,8 +238,7 @@ if __name__ == "__main__":
     logger.info("-----------------------------------------")
     if not PYDOT_AVAILABLE:
         logger.warning(
-            "pydot library not found. Export functions will raise "
-            "PydotImportError."
+            "pydot library not found. Export functions will raise " "PydotImportError."
         )
         logger.warning("Please install it: pip install pydot")
     else:
@@ -267,9 +274,7 @@ if __name__ == "__main__":
 
                 # Build DAG
                 test_dag = DAG()
-                test_dag.build_dag(
-                    [future_c]
-                )  # Build with the terminal future
+                test_dag.build_dag([future_c])  # Build with the terminal future
                 test_dag.validate_dag()  # Ensure it's valid
                 logger.info("Dummy DAG created successfully for testing.")
 
@@ -278,17 +283,12 @@ if __name__ == "__main__":
                 try:
                     dot_str = dag_to_dot_string(test_dag)
                     logger.info(
-                        "DOT String generated (first 100 chars): "
-                        f"{dot_str[:100]}..."
+                        "DOT String generated (first 100 chars): " f"{dot_str[:100]}..."
                     )
                     # Example: save to a file
-                    with open(
-                        "test_dag_output.dot", "w", encoding="utf-8"
-                    ) as f:
+                    with open("test_dag_output.dot", "w", encoding="utf-8") as f:
                         f.write(dot_str)
-                    logger.info(
-                        "Full DOT string saved to test_dag_output.dot"
-                    )
+                    logger.info("Full DOT string saved to test_dag_output.dot")
                 except Exception as e_dot:
                     logger.error(
                         "Error in dag_to_dot_string test: %s",
@@ -307,8 +307,7 @@ if __name__ == "__main__":
                     # save_dag_to_png now uses the module logger, so it works
                     # correctly when called outside of a class.
                     logger.info(
-                        "DAG visualization attempt to save to "
-                        f"{png_output_path}."
+                        "DAG visualization attempt to save to " f"{png_output_path}."
                     )
                     logger.info(
                         "If Graphviz 'dot' is installed and in PATH, "
@@ -329,9 +328,7 @@ if __name__ == "__main__":
                 except (
                     PydotImportError
                 ) as pie:  # Should be caught earlier by PYDOT_AVAILABLE
-                    logger.error(
-                        f"PNG EXPORT FAILED: Pydot library not found. {pie}"
-                    )
+                    logger.error(f"PNG EXPORT FAILED: Pydot library not found. {pie}")
                 except Exception as e_viz:
                     logger.error(
                         "Error in save_dag_to_png test: "
@@ -345,9 +342,7 @@ if __name__ == "__main__":
                     exc_info=True,
                 )
         else:
-            logger.warning(
-                "\nSkipping DAG export tests as pydot is not available."
-            )
+            logger.warning("\nSkipping DAG export tests as pydot is not available.")
 
     except ImportError:
         logger.error(

--- a/parslet/core/parsl_bridge.py
+++ b/parslet/core/parsl_bridge.py
@@ -1,4 +1,7 @@
-"""Parsl compatibility helpers for Parslet."""
+"""Parsl compatibility helpers for Parslet.
+
+Public API: :func:`convert_task_to_parsl` and :func:`execute_with_parsl`.
+"""
 
 from __future__ import annotations
 
@@ -8,6 +11,9 @@ import tempfile
 
 from .dag import DAG
 from .task import ParsletFuture
+
+
+__all__ = ["convert_task_to_parsl", "execute_with_parsl"]
 
 
 def convert_task_to_parsl(parslet_func):

--- a/parslet/core/scheduler.py
+++ b/parslet/core/scheduler.py
@@ -1,4 +1,7 @@
-"""Adaptive scheduling utilities for Parslet."""
+"""Adaptive scheduling utilities for Parslet.
+
+Public API: :class:`AdaptiveScheduler` used by :class:`~parslet.core.runner.DAGRunner`.
+"""
 
 from __future__ import annotations
 
@@ -10,6 +13,8 @@ from ..utils.resource_utils import (
     get_available_ram_mb,
     get_battery_level,
 )
+
+__all__ = ["AdaptiveScheduler"]
 
 
 class AdaptiveScheduler:

--- a/parslet/core/task.py
+++ b/parslet/core/task.py
@@ -1,4 +1,8 @@
-"""Task utilities and decorators for building Parslet DAGs."""
+"""Task utilities and decorators for building Parslet DAGs.
+
+Public API: :func:`parslet_task`, :class:`ParsletFuture` and
+``set_allow_redefine``.
+"""
 
 import functools
 import logging
@@ -23,6 +27,8 @@ _RESULT_NOT_SET = object()
 
 # Module-level logger for task utilities
 logger = logging.getLogger(__name__)
+
+__all__ = ["parslet_task", "ParsletFuture", "set_allow_redefine"]
 
 
 class ParsletFuture:
@@ -91,8 +97,7 @@ class ParsletFuture:
             str: A string like "<ParsletFuture task_id='...' func='...'>".
         """
         return (
-            f"<ParsletFuture task_id='{self.task_id}' "
-            f"func='{self.func.__name__}'>"
+            f"<ParsletFuture task_id='{self.task_id}' " f"func='{self.func.__name__}'>"
         )
 
     def set_result(self, value: Any) -> None:
@@ -249,9 +254,7 @@ def parslet_task(
         # primarily uses direct function references stored in ParsletFutures.
         if task_name in _TASK_REGISTRY:
             existing_func = _TASK_REGISTRY[task_name]
-            existing_protected = getattr(
-                existing_func, "_parslet_protected", False
-            )
+            existing_protected = getattr(existing_func, "_parslet_protected", False)
             if existing_protected and not _ALLOW_REDEFINE:
                 raise ValueError(
                     f"Task '{task_name}' is protected and already defined. "
@@ -264,8 +267,7 @@ def parslet_task(
                 )
             else:
                 logger.warning(
-                    "Parslet task '%s' is being redefined. Ensure this is "
-                    "intended.",
+                    "Parslet task '%s' is being redefined. Ensure this is " "intended.",
                     task_name,
                 )
         _TASK_REGISTRY[task_name] = func_to_wrap

--- a/tests/test_api_surface.py
+++ b/tests/test_api_surface.py
@@ -1,0 +1,6 @@
+import parslet
+
+
+def test_top_level_public_api() -> None:
+    expected = {"parslet_task", "ParsletFuture", "DAG", "DAGRunner"}
+    assert set(parslet.__all__) == expected


### PR DESCRIPTION
## Summary
- document core Parslet architecture and minimal API
- clarify module responsibilities and expose explicit `__all__`
- add test locking down top-level public symbols

## Testing
- `black -q parslet/__init__.py parslet/core/__init__.py parslet/core/dag.py parslet/core/dag_io.py parslet/core/dask_bridge.py parslet/core/exporter.py parslet/core/parsl_bridge.py parslet/core/runner.py parslet/core/scheduler.py parslet/core/task.py tests/test_api_surface.py`
- `ruff check parslet/__init__.py parslet/core/__init__.py parslet/core/dag.py parslet/core/dag_io.py parslet/core/dask_bridge.py parslet/core/exporter.py parslet/core/parsl_bridge.py parslet/core/runner.py parslet/core/scheduler.py parslet/core/task.py tests/test_api_surface.py --select E,F`
- `flake8 --max-line-length=88 tests/test_api_surface.py parslet/__init__.py parslet/core/__init__.py`
- `mypy parslet/core/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8c8cfd2a083338fc7317bbdbde519