### PR TITLE
feat(cache): deterministic task caching with content hashes + tests

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,0 +1,15 @@
+# Task Caching
+
+Parslet tasks may opt into result caching by specifying `cache=True` in the
+`@parslet_task` decorator. Cached results are keyed by a deterministic hash of
+all task inputs and an optional version string.
+
+Caching is disabled unless a task requests it, and it can be globally disabled
+via the `--no-cache` CLI flag or the `PARSLET_NO_CACHE` environment variable.
+
+Cached data is stored under `~/.parslet/cache` by default. Set
+`PARSLET_CACHE_DIR` to override the location. Results are serialized with
+Python's `pickle` module, so task return values must be pickle‑safe.
+
+Cache files are not automatically invalidated. When task logic changes, bump the
+`version` parameter in the decorator to compute a new cache key.

--- a/parslet/core/cache.py
+++ b/parslet/core/cache.py
@@ -1,0 +1,84 @@
+"""Deterministic task result caching utilities."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import pickle
+from pathlib import Path
+
+__all__ = ["compute_cache_key", "load_from_cache", "save_to_cache", "get_cache_dir"]
+
+
+def _safe_serialize(obj: object) -> object:
+    """Serialize ``obj`` into JSON-friendly structures.
+
+    Non-JSON-serializable objects fall back to ``repr`` strings. Collections
+    are processed recursively to ensure deterministic ordering.
+    """
+    if isinstance(obj, str | int | float | bool) or obj is None:
+        return obj
+    if isinstance(obj, list | tuple):
+        return [_safe_serialize(i) for i in obj]
+    if isinstance(obj, dict):
+        return {k: _safe_serialize(v) for k, v in sorted(obj.items())}
+    try:
+        json.dumps(obj)
+        return obj
+    except TypeError:
+        return repr(obj)
+
+
+def compute_cache_key(
+    task_name: str,
+    args: tuple[object, ...],
+    kwargs: dict[str, object],
+    version: str = "1",
+) -> str:
+    """Compute a deterministic hash for a task invocation.
+
+    Parameters
+    ----------
+    task_name:
+        Registered name of the task.
+    args:
+        Positional arguments supplied to the task.
+    kwargs:
+        Keyword arguments supplied to the task.
+    version:
+        Optional manual version string to bust caches when the implementation
+        changes.
+    """
+    payload = {
+        "task": task_name,
+        "version": version,
+        "args": _safe_serialize(args),
+        "kwargs": _safe_serialize(kwargs),
+    }
+    data = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(data).hexdigest()
+
+
+def get_cache_dir() -> Path:
+    """Return the directory used for storing cache files."""
+    base = os.environ.get("PARSLET_CACHE_DIR", os.path.expanduser("~/.parslet/cache"))
+    path = Path(base)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def load_from_cache(key: str) -> object:
+    """Load a cached value for ``key`` if present."""
+    cache_file = get_cache_dir() / f"{key}.pkl"
+    if cache_file.exists():
+        with cache_file.open("rb") as fh:
+            return pickle.load(fh)
+    raise FileNotFoundError(key)
+
+
+def save_to_cache(key: str, value: object) -> None:
+    """Persist ``value`` for ``key`` to the cache."""
+    cache_file = get_cache_dir() / f"{key}.pkl"
+    with cache_file.open("wb") as fh:
+        pickle.dump(value, fh)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from parslet.core import DAG, DAGRunner
+from parslet.core.task import parslet_task
+
+calls: list[int] = []
+
+
+@parslet_task(cache=True)
+def slow_double(x: int) -> int:
+    calls.append(x)
+    time.sleep(0.1)
+    return x * 2
+
+
+def _run_once() -> float:
+    dag = DAG()
+    fut = slow_double(2)
+    dag.build_dag([fut])
+    runner = DAGRunner()
+    start = time.perf_counter()
+    runner.run(dag)
+    duration = time.perf_counter() - start
+    assert fut.result() == 4
+    return duration
+
+
+def test_task_caching(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("PARSLET_CACHE_DIR", str(tmp_path))
+    d1 = _run_once()
+    assert calls == [2]
+    d2 = _run_once()
+    assert calls == [2]
+    assert d2 < d1 / 5


### PR DESCRIPTION
## Summary
- add opt-in task caching with deterministic hash keys and on-disk pickle store
- allow tasks to request caching via `@parslet_task(cache=True, version='1')`
- support global disable with `--no-cache`/`PARSLET_NO_CACHE`
- document caching behavior and add regression test

## Testing
- `ruff check parslet/core/task.py tests/test_cache.py parslet/core/cache.py parslet/core/runner.py parslet/main_cli.py`
- `black parslet/core/cache.py parslet/core/task.py parslet/core/runner.py parslet/main_cli.py tests/test_cache.py`
- `mypy parslet/core/cache.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8d0c798bc8333a47d7de5e1d21317