### PR TITLE
feat(scheduler): AdaptivePolicy + JSON pool resize logs; CLI --battery-mode

### DIFF
--- a/docs/source/battery_mode.rst
+++ b/docs/source/battery_mode.rst
@@ -6,9 +6,9 @@ We've all been there. You're in the middle of something important, and you see t
 How Does It Work?
 -----------------
 
-When you tell Parslet to run in battery-saver mode, its smart scheduler (the ``AdaptiveScheduler``) gets extra cautious. It looks at your device's CPU, available memory, and most importantly, your current battery percentage.
+When you tell Parslet to run in battery-saver mode, an :class:`AdaptivePolicy` kicks in. It looks at your device's CPU, available memory, and most importantly, your current battery percentage.
 
-Based on what it sees, it will reduce the number of tasks it tries to run at the same time. Often, it will slow down to running just one task at a time. This is like putting your phone into "Low Power Mode"—it helps your battery last as long as possible so you can finish your work.
+Based on what it sees, the policy decides how many worker threads to keep alive. If the battery drops below about 40%, the pool is automatically cut in half; when the battery recovers, it can grow again up to its cap. Often, it will slow down to running just one task at a time. This is like putting your phone into "Low Power Mode"—it helps your battery last as long as possible so you can finish your work.
 
 How Do I Turn It On?
 --------------------

--- a/parslet/core/__init__.py
+++ b/parslet/core/__init__.py
@@ -20,6 +20,7 @@ from .runner import (  # noqa: F401
     UpstreamTaskFailedError,
 )
 from .scheduler import AdaptiveScheduler  # noqa: F401
+from .policy import AdaptivePolicy  # noqa: F401
 from .task import ParsletFuture, parslet_task, set_allow_redefine  # noqa: F401
 
 try:
@@ -27,4 +28,11 @@ try:
 except metadata.PackageNotFoundError:  # pragma: no cover
     __version__ = "0.0.0"
 
-__all__ = ["parslet_task", "ParsletFuture", "DAG", "DAGRunner"]
+__all__ = [
+    "parslet_task",
+    "ParsletFuture",
+    "DAG",
+    "DAGRunner",
+    "AdaptivePolicy",
+    "AdaptiveScheduler",
+]

--- a/parslet/core/policy.py
+++ b/parslet/core/policy.py
@@ -1,0 +1,30 @@
+"""Resource-aware worker pool policy."""
+
+from dataclasses import dataclass
+
+from ..utils.resource_utils import ResourceSnapshot
+
+
+@dataclass
+class AdaptivePolicy:
+    """Decide worker pool size based on system resources."""
+
+    max_workers: int | None = None
+    min_free_ram_mb: int = 256
+    battery_threshold: int = 30
+
+    def decide_pool_size(self, probes: ResourceSnapshot) -> int:
+        """Return desired worker count given current resource probes."""
+
+        workers = probes.cpu_count
+        if self.max_workers is not None:
+            workers = min(workers, self.max_workers)
+        if probes.available_ram_mb is not None:
+            ram_based = max(1, int(probes.available_ram_mb // self.min_free_ram_mb))
+            workers = min(workers, ram_based)
+        if (
+            probes.battery_level is not None
+            and probes.battery_level < self.battery_threshold
+        ):
+            workers = max(1, workers // 2)
+        return max(1, workers)

--- a/parslet/utils/__init__.py
+++ b/parslet/utils/__init__.py
@@ -2,16 +2,21 @@
 
 import logging
 
-try:
-    from rich.logging import RichHandler
-except Exception:  # pragma: no cover - rich is optional
-    RichHandler = None
-
 from .resource_utils import (
-    get_cpu_count,
+    ResourceSnapshot,
     get_available_ram_mb,
     get_battery_level,
+    get_cpu_count,
+    probe_resources,
 )
+
+RichHandler: type | None
+try:
+    from rich.logging import RichHandler as _RichHandler
+
+    RichHandler = _RichHandler
+except Exception:  # pragma: no cover - rich is optional
+    RichHandler = None
 
 
 def get_parslet_logger(
@@ -48,5 +53,7 @@ __all__ = [
     "get_cpu_count",
     "get_available_ram_mb",
     "get_battery_level",
+    "probe_resources",
+    "ResourceSnapshot",
     "get_parslet_logger",
 ]

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,24 @@
+import pytest
+
+from parslet.core.policy import AdaptivePolicy
+from parslet.utils import resource_utils
+
+
+def test_policy_shrinks_on_low_battery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(resource_utils, "get_cpu_count", lambda: 8)
+    monkeypatch.setattr(resource_utils, "get_available_ram_mb", lambda: 4096)
+    monkeypatch.setattr(resource_utils, "get_battery_level", lambda: 10)
+    policy = AdaptivePolicy(max_workers=8)
+    snapshot = resource_utils.probe_resources()
+    assert policy.decide_pool_size(snapshot) == 4
+
+
+def test_policy_expands_to_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(resource_utils, "get_cpu_count", lambda: 8)
+    monkeypatch.setattr(resource_utils, "get_available_ram_mb", lambda: 4096)
+    monkeypatch.setattr(resource_utils, "get_battery_level", lambda: 80)
+    policy = AdaptivePolicy(max_workers=8)
+    snapshot = resource_utils.probe_resources()
+    assert policy.decide_pool_size(snapshot) == 8


### PR DESCRIPTION
## Summary
- add AdaptivePolicy for dynamic worker pool sizing
- log thread pool resizes (JSON when requested)
- expose battery saver mode through CLI and docs

## Testing
- `ruff check parslet/core/policy.py parslet/core/runner.py parslet/core/scheduler.py parslet/utils/resource_utils.py parslet/utils/__init__.py parslet/main_cli.py tests/test_policy.py`
- `black --line-length 88 parslet/core/runner.py parslet/utils/resource_utils.py parslet/utils/__init__.py parslet/core/scheduler.py tests/test_policy.py`
- `mypy parslet/core/policy.py parslet/core/runner.py parslet/core/scheduler.py parslet/utils/resource_utils.py parslet/utils/__init__.py parslet/main_cli.py tests/test_policy.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8dd283518833395c4c5a1f93507de