### PR TITLE
feat(security): sentries for name collisions, shell guard, offline lock

### DIFF
--- a/docs/sentries.md
+++ b/docs/sentries.md
@@ -1,0 +1,26 @@
+# Security Sentries
+
+Parslet ships with a small set of *sentries* that keep workflows honest. Each
+sentry is opt‑out: behaviour is locked down by default and tasks must
+explicitly request more power.
+
+## Task name sovereignty
+
+Tasks are registered under their function name. Registering a second task with
+the same name now raises an error to prevent accidental collisions. If a
+redefinition is intentional use `@parslet_task(..., allow_redefine=True)`.
+
+## Shell guard
+
+Invoking `os.system` or `subprocess` helpers is blocked when tasks run. To run
+shell commands add `allow_shell=True` to the task decorator. Without it a
+helpful `SecurityError` is raised.
+
+## Offline lock
+
+Running the CLI with `--offline` prevents creation of sockets so that no
+network traffic occurs. Any attempted network access will raise a
+`SecurityError` suggesting removing the flag.
+
+These sentries aim to provide sensible defaults while still allowing expert
+users to override them when necessary.

--- a/parslet/core/runner.py
+++ b/parslet/core/runner.py
@@ -18,6 +18,7 @@ from typing import Any
 
 # Absolute import avoids issues when ``parslet`` is imported under
 # an alternative package name (e.g. ``Parslet`` during pytest collection).
+from parslet.security import shell_guard
 from parslet.security.defcon import Defcon
 
 from ..utils.checkpointing import CheckpointManager
@@ -340,8 +341,10 @@ class DAGRunner:
         kwargs: dict[str, object],
     ) -> object:
         """Execute a task function and translate resource errors."""
+        allow_shell = getattr(parslet_future.func, "_parslet_allow_shell", False)
         try:
-            return parslet_future.func(*args, **kwargs)
+            with shell_guard(allow_shell):
+                return parslet_future.func(*args, **kwargs)
         except (MemoryError, OSError) as e:
             raise ResourceLimitError(str(e)) from e
 

--- a/parslet/main_cli.py
+++ b/parslet/main_cli.py
@@ -8,6 +8,8 @@ It is intended to be simple to keep the barrier to entry low for new users.
 import argparse
 import sys
 
+from parslet.security import offline_guard
+
 from .plugins.loader import load_plugins
 from .utils import get_parslet_logger
 
@@ -26,6 +28,7 @@ def cli() -> None:
     run_p.add_argument("--battery-mode", action="store_true")
     run_p.add_argument("--json-logs", action="store_true")
     run_p.add_argument("--failsafe-mode", action="store_true")
+    run_p.add_argument("--offline", action="store_true", help="Disable network access")
     run_p.add_argument(
         "--simulate",
         action="store_true",
@@ -120,7 +123,8 @@ def cli() -> None:
         if args.monitor:
 
             def _run() -> None:
-                runner.run(dag)
+                with offline_guard(args.offline):
+                    runner.run(dag)
 
             t = threading.Thread(target=_run)
             t.start()
@@ -141,7 +145,8 @@ def cli() -> None:
                     table.add_row(tid, status)
                 live.update(table)
         else:
-            runner.run(dag)
+            with offline_guard(args.offline):
+                runner.run(dag)
     elif args.cmd == "rad":
         from examples.rad_parslet.rad_dag import main as rad_main
         from parslet.core import DAG, DAGRunner

--- a/parslet/security/__init__.py
+++ b/parslet/security/__init__.py
@@ -1,0 +1,97 @@
+"""Runtime security sentries for Parslet.
+
+These lightweight guards block risky behaviour unless tasks opt in
+explicitly.  The module provides two context managers used by the runner:
+
+* :func:`shell_guard` – prevents invocation of ``os.system`` and common
+  ``subprocess`` helpers unless a task is decorated with
+  ``@parslet_task(allow_shell=True)``.
+* :func:`offline_guard` – when enabled (``--offline`` CLI flag), creation of
+  sockets is blocked to keep execution fully offline.
+
+Both guards raise :class:`SecurityError` with a clear remediation hint when
+violated.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import NoReturn
+
+__all__ = ["SecurityError", "shell_guard", "offline_guard"]
+
+
+class SecurityError(RuntimeError):
+    """Raised when a security sentry blocks an operation."""
+
+
+@contextmanager
+def shell_guard(allow: bool) -> Iterator[None]:
+    """Block shell execution if ``allow`` is :data:`False`.
+
+    The guard temporarily monkey patches :mod:`os` and :mod:`subprocess`
+    helpers so that any attempt to spawn a shell raises :class:`SecurityError`.
+    Tasks that genuinely require shell access must opt in via
+    ``@parslet_task(allow_shell=True)``.
+    """
+
+    if allow:
+        # Nothing to do when shell access is explicitly allowed.
+        yield
+        return
+
+    original_os_system = os.system
+    original_run = subprocess.run
+    original_popen = subprocess.Popen
+    original_call = subprocess.call
+    original_check_output = subprocess.check_output
+
+    def _blocked(*args: object, **kwargs: object) -> NoReturn:  # type: ignore[unused-arg]
+        raise SecurityError(
+            "Shell commands are disabled for this task. "
+            "Use @parslet_task(allow_shell=True) to enable."
+        )
+
+    class _BlockedPopen(subprocess.Popen):  # type: ignore[type-arg]
+        def __init__(self, *args: object, **kwargs: object) -> None:  # type: ignore[override]
+            _blocked()
+
+    os.system = _blocked  # type: ignore[assignment]
+    subprocess.run = _blocked  # type: ignore[assignment]
+    subprocess.call = _blocked  # type: ignore[assignment]
+    subprocess.check_output = _blocked  # type: ignore[assignment]
+    subprocess.Popen = _BlockedPopen  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        os.system = original_os_system  # type: ignore[assignment]
+        subprocess.run = original_run  # type: ignore[assignment]
+        subprocess.Popen = original_popen  # type: ignore[assignment]
+        subprocess.call = original_call  # type: ignore[assignment]
+        subprocess.check_output = original_check_output  # type: ignore[assignment]
+
+
+@contextmanager
+def offline_guard(enabled: bool) -> Iterator[None]:
+    """Block network socket creation when ``enabled`` is :data:`True`."""
+
+    if not enabled:
+        yield
+        return
+
+    original_socket = socket.socket
+
+    def _blocked_socket(*args: object, **kwargs: object) -> NoReturn:  # type: ignore[unused-arg]
+        raise SecurityError(
+            "Network access disabled via --offline. Remove flag to enable."
+        )
+
+    socket.socket = _blocked_socket  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        socket.socket = original_socket  # type: ignore[assignment]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from parslet.core.task import set_allow_redefine
+
+
+def pytest_sessionstart(session):
+    """Allow task redefinition across tests by default."""
+    set_allow_redefine(True)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,70 @@
+import os
+import socket
+
+import pytest
+
+from parslet.core import DAG, DAGRunner, parslet_task
+from parslet.core.task import _TASK_REGISTRY, set_allow_redefine
+from parslet.security import SecurityError, offline_guard
+
+
+def test_name_collision_and_allow_redefine() -> None:
+    set_allow_redefine(False)
+    try:
+
+        @parslet_task(name="dup_test")
+        def first() -> int:
+            return 1
+
+        with pytest.raises(ValueError):
+
+            @parslet_task(name="dup_test")
+            def second() -> int:
+                return 2
+
+        @parslet_task(name="dup_test", allow_redefine=True)
+        def third() -> int:
+            return 3
+
+    finally:
+        _TASK_REGISTRY.pop("dup_test", None)
+        set_allow_redefine(True)
+
+
+def test_shell_guard_blocks_and_allows() -> None:
+    @parslet_task(name="sh_block")
+    def sh_block() -> None:
+        os.system("true")
+
+    @parslet_task(name="sh_allow", allow_shell=True)
+    def sh_allow() -> int:
+        return os.system("true")
+
+    fut_block = sh_block()
+    fut_allow = sh_allow()
+
+    dag_block = DAG()
+    dag_block.build_dag([fut_block])
+    dag_allow = DAG()
+    dag_allow.build_dag([fut_allow])
+
+    runner = DAGRunner()
+    with pytest.raises(SecurityError):
+        runner.run(dag_block)
+
+    runner = DAGRunner()
+    runner.run(dag_allow)
+    assert fut_allow.result() == 0
+
+    _TASK_REGISTRY.pop("sh_block", None)
+    _TASK_REGISTRY.pop("sh_allow", None)
+
+
+def test_offline_guard_blocks_socket() -> None:
+    with offline_guard(True):
+        with pytest.raises(SecurityError):
+            socket.socket()
+    # And when disabled it should work
+    with offline_guard(False):
+        s = socket.socket()
+        s.close()

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,55 +1,63 @@
-from parslet.core import parslet_task, ParsletFuture
-from parslet.core.task import _TASK_REGISTRY, set_allow_redefine
 import pytest
+
+from parslet.core import ParsletFuture, parslet_task
+from parslet.core.task import _TASK_REGISTRY, set_allow_redefine
 
 
 @parslet_task
-def add(x, y):
+def add(x: int, y: int) -> int:
     return x + y
 
 
 @parslet_task(battery_sensitive=True)
-def sensitive(x):
+def sensitive(x: int) -> int:
     return x
 
 
-def test_parslet_task_decorator_returns_future():
+def test_parslet_task_decorator_returns_future() -> None:
     fut = add(1, 2)
     assert isinstance(fut, ParsletFuture)
     assert fut.func.__name__ == "add"
 
 
-def test_battery_sensitive_metadata():
+def test_battery_sensitive_metadata() -> None:
     assert getattr(sensitive, "_parslet_battery_sensitive", False) is True
 
 
-def test_protected_task_redefinition_error():
-    @parslet_task(name="prot", protected=True)
-    def first():
-        return 1
-
-    with pytest.raises(ValueError):
+def test_protected_task_redefinition_error() -> None:
+    set_allow_redefine(False)
+    try:
 
         @parslet_task(name="prot", protected=True)
-        def second():
-            return 2
+        def first() -> int:
+            return 1
 
-    _TASK_REGISTRY.pop("prot", None)
+        with pytest.raises(ValueError):
+
+            @parslet_task(name="prot", protected=True)
+            def second() -> int:
+                return 2
+
+    finally:
+        _TASK_REGISTRY.pop("prot", None)
+        set_allow_redefine(True)
 
 
-def test_force_redefine_allows_protected_task():
+def test_force_redefine_allows_protected_task() -> None:
+    set_allow_redefine(False)
+
     @parslet_task(name="prot_force", protected=True)
-    def base():
+    def base() -> int:
         return 1
 
     set_allow_redefine(True)
     try:
 
         @parslet_task(name="prot_force", protected=True)
-        def redefine():
+        def redefine() -> int:
             return 2
 
     finally:
-        set_allow_redefine(False)
+        set_allow_redefine(True)
     assert "prot_force" in _TASK_REGISTRY
     _TASK_REGISTRY.pop("prot_force", None)


### PR DESCRIPTION
## Summary
- enforce unique task names with optional override
- guard shell commands and network sockets unless explicitly allowed
- document and test security sentries

## Testing
- `ruff check parslet/core/task.py parslet/core/runner.py parslet/main_cli.py parslet/security/__init__.py tests/test_security.py tests/test_task.py`
- `flake8 --max-line-length 88 --extend-ignore=E501,W503 parslet/core/task.py parslet/core/runner.py parslet/main_cli.py parslet/security/__init__.py tests/test_security.py tests/test_task.py`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a9b8a496e883338e4108ade1428350