### PR TITLE
feat(cli): richer errors, module target, and new flags docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ Ready to try it? You can be up and running in less than a minute.
 
 You'll see the `print` statements from your tasks as they run, in the correct order 🎉
 
+You can also reference a workflow by module path and tweak execution:
+
+```bash
+parslet run my_package.workflow:main --max-workers 4 --json-logs --export-stats stats.json
+```
+
 ---
 
 ## What Else Can It Do? 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,3 +7,17 @@ from parslet import parslet_task, DAG, DAGRunner, ParsletFuture
 ```
 
 These four names form Parslet's stable public API.
+
+## Command-line execution
+
+Run a workflow script directly:
+
+```bash
+parslet run path/to/workflow.py --max-workers 2
+```
+
+Workflows installed as modules are also supported:
+
+```bash
+parslet run pkg.workflow:main --json-logs --export-stats stats.json
+```

--- a/parslet/cli.py
+++ b/parslet/cli.py
@@ -1,22 +1,38 @@
+import sys
+from importlib import import_module
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 from types import ModuleType
-import sys
 
 
 def load_workflow_module(path: str) -> ModuleType:
-    """Load a workflow script as a Python module from ``path``.
+    """Load a workflow script or module reference.
+
+    The ``path`` can either be a filesystem path to a Python file or a
+    ``module:func`` reference. In the latter case the referenced callable is
+    exposed as ``main`` on the returned module to match the traditional file
+    workflow interface.
 
     Parameters
     ----------
     path: str
-        Filesystem path to the workflow script.
+        Filesystem path to the workflow script or ``module:func`` reference.
 
     Returns
     -------
     ModuleType
-        The loaded Python module.
+        The loaded Python module with a ``main`` attribute.
     """
+
+    if ":" in path and not Path(path).exists():
+        mod_name, func_name = path.split(":", 1)
+        module = import_module(mod_name)
+        if not hasattr(module, func_name):
+            raise ImportError(f"Module '{mod_name}' has no attribute '{func_name}'")
+        # Expose the target callable as ``main`` for CLI expectations
+        module.main = getattr(module, func_name)  # type: ignore[attr-defined]
+        return module
+
     wf_path = Path(path).resolve()
     spec = spec_from_file_location(wf_path.stem, wf_path)
     if spec and spec.loader:

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -1,0 +1,16 @@
+from importlib import import_module
+
+import pytest
+
+
+def test_run_help_shows_new_flags(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = import_module("parslet.main_cli")
+    module.sys.argv = ["parslet", "run", "--help"]
+    with pytest.raises(SystemExit):
+        module.main()
+    out = capsys.readouterr().out
+    assert "--max-workers" in out
+    assert "--json-logs" in out
+    assert "--export-stats" in out

--- a/tests/test_fail_messages.py
+++ b/tests/test_fail_messages.py
@@ -1,0 +1,23 @@
+import logging
+
+import pytest
+
+from parslet import parslet_task
+from parslet.core import DAG, DAGRunner
+
+
+def test_failure_log_contains_task_details(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    @parslet_task
+    def boom() -> None:
+        raise FileNotFoundError("missing")
+
+    fut = boom()
+    dag = DAG()
+    dag.build_dag([fut])
+    runner = DAGRunner()
+    with caplog.at_level(logging.ERROR):
+        runner.run(dag)
+    assert fut.task_id in caplog.text
+    assert "boom" in caplog.text


### PR DESCRIPTION
## Summary
- improve runner failure logs with node, function, predecessors and hints
- support `module:func` workflow references and add max-worker/json-logs/export-stats flags
- document new flags and CLI examples

## Testing
- `ruff check parslet/cli.py parslet/main_cli.py parslet/core/runner.py tests/test_cli_help.py tests/test_fail_messages.py`
- `mypy parslet/cli.py parslet/main_cli.py parslet/core/runner.py tests/test_cli_help.py tests/test_fail_messages.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac73c6abd88333a40d51ab51a4657f