### PR TITLE
docs(examples): sync examples with new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,16 +136,16 @@ parslet run my_package.workflow:main --max-workers 4 --json-logs --export-stats 
 
 ---
 
-## What Else Can It Do? 
+## What Else Can It Do?
 
 Parslet is small, but it's packed with neat features for real-world use.
 
--   **Works Offline:** Your automated workflows run even without an internet connection.
--   **Saves Battery:** Use the special `--battery-mode` to tell Parslet to take it easy and conserve power.
--   **Smart About Resources:** It automatically checks your device's CPU and memory to run smoothly without crashing.
--   **DEFCON:** A multi-layered defense system in Parslet that proactively blocks zero-day exploits and malicious DAG behavior using offline rules.
--   **Plays Well with Others:** If you ever move to a big server, Parslet has tools to convert your recipes to run on powerful systems like Parsl or Dask.
--   **Made for Termux:** We use it and test it on Android phones, so you know it'll work.
+-   **Works Offline:** Your automated workflows run even without an internet connection. See the [examples](docs/examples.md).
+-   **Saves Battery:** Use the special `--battery-mode` to tell Parslet to take it easy and conserve power. Read about [battery mode](docs/source/battery_mode.rst).
+-   **Smart About Resources:** It automatically checks your device's CPU and memory to run smoothly without crashing. The [AdaptivePolicy](docs/policy.md) adjusts workers on the fly.
+-   **DEFCON:** A multi-layered defense system in Parslet that proactively blocks zero-day exploits and malicious DAG behavior using offline rules. Learn more in the [security notes](docs/technical-overview.md).
+-   **Plays Well with Others:** If you ever move to a big server, Parslet has tools to convert your recipes to run on powerful systems like Parsl or Dask. See [compatibility](docs/compatibility.md).
+-   **Made for Termux:** We use it and test it on Android phones, so you know it'll work. Check the [install guide](docs/install.md).
 
 Want to see more? Check out the `use_cases/` and `examples/` folders for more advanced recipes!
 

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -4,6 +4,27 @@ Parslet tasks may opt into result caching by specifying `cache=True` in the
 `@parslet_task` decorator. Cached results are keyed by a deterministic hash of
 all task inputs and an optional version string.
 
+```python
+from parslet.core import DAG, DAGRunner, parslet_task
+
+
+@parslet_task(cache=True)
+def slow_double(x: int) -> int:
+    print("doubling", x)
+    return x * 2
+
+
+def main() -> list:
+    dag = DAG()
+    fut = slow_double(5)
+    dag.build_dag([fut])
+    DAGRunner().run(dag)
+    return [fut]
+```
+
+Run the script twice and the second invocation will reuse the cached result.
+See `examples/cached_task.py` for the full version.
+
 Caching is disabled unless a task requests it, and it can be globally disabled
 via the `--no-cache` CLI flag or the `PARSLET_NO_CACHE` environment variable.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -14,6 +14,9 @@ Parsl `@python_app` functions are rewritten as `@parslet_task` and any top
 level task invocations are wrapped into a `main()` function returning a list of
 `ParsletFuture` objects.
 
+See `examples/compat/parsl_demo.py` for a minimal workflow that can be
+converted.
+
 ## Export to Parsl
 
 ```
@@ -47,3 +50,6 @@ parslet convert --from-dask in.py --to-parslet out.py
 ```
 parslet convert --from-parslet in.py --to-dask out.py
 ```
+
+The `examples/compat/dask_demo.py` script shows a tiny Dask workflow that
+works with the converter.

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -1,0 +1,24 @@
+# Adaptive Policy
+
+`AdaptivePolicy` lets Parslet scale worker threads based on current resources.
+
+```python
+from parslet.core import DAG, DAGRunner, parslet_task
+from parslet.core.policy import AdaptivePolicy
+
+@parslet_task
+def work() -> None:
+    print("task running")
+
+
+def main() -> list:
+    dag = DAG()
+    fut = work()
+    dag.build_dag([fut])
+    policy = AdaptivePolicy(max_workers=4)
+    DAGRunner(policy=policy).run(dag)
+    return [fut]
+```
+
+The policy can shrink or expand the worker pool as resources change.
+See `examples/policy_example.py` for a runnable script.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -59,6 +59,17 @@ By default, it looks at your device's CPU cores and available memory to pick a s
 
 If you're on a laptop or phone and want to save battery, just add the ``--battery-mode`` flag. This tells Parslet to take it easy and run fewer tasks at the same time. You can always override this with ``--max-workers`` if you know best.
 
-Want to see what's happening in real-time? Use the ``--monitor`` flag to get a live view of your tasks as they run.
+Want to see what's happening in real-time? Use the ``--monitor`` flag:
+
+.. code-block:: bash
+
+   parslet run my_flow.py --monitor
+
+To analyze performance, export execution stats and plot an ASCII heatmap:
+
+.. code-block:: bash
+
+   parslet run my_flow.py --export-stats stats.json
+   python examples/tools/plot_stats.py stats.json
 
 For more command-line options, like exporting a picture of your workflow, check out the :doc:`cli` guide. To learn more about how battery mode works, see :doc:`battery_mode`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -21,3 +21,15 @@ Workflows installed as modules are also supported:
 ```bash
 parslet run pkg.workflow:main --json-logs --export-stats stats.json
 ```
+
+Watch tasks live with ``--monitor``:
+
+```bash
+parslet run path/to/workflow.py --monitor
+```
+
+And turn exported stats into an ASCII heatmap:
+
+```bash
+python examples/tools/plot_stats.py stats.json
+```

--- a/examples/cached_task.py
+++ b/examples/cached_task.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from parslet.core import DAG, DAGRunner, ParsletFuture, parslet_task
+
+
+@parslet_task(cache=True)
+def slow_double(x: int) -> int:
+    """Expensive computation that benefits from caching."""
+    print(f"doubling {x}")
+    return x * 2
+
+
+def main() -> list[ParsletFuture]:
+    """Build and run a DAG with a cached task."""
+    dag = DAG()
+    fut = slow_double(5)
+    dag.build_dag([fut])
+    DAGRunner().run(dag)
+    return [fut]

--- a/examples/compat/dask_demo.py
+++ b/examples/compat/dask_demo.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from dask import compute, delayed
+
+
+@delayed
+def add(x: int, y: int) -> int:
+    return x + y
+
+
+def main() -> int:
+    return compute(add(1, 2))[0]

--- a/examples/compat/parsl_demo.py
+++ b/examples/compat/parsl_demo.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from parsl import python_app
+
+
+@python_app
+def add(x: int, y: int) -> int:
+    return x + y
+
+
+def main() -> int:
+    fut = add(1, 2)
+    return fut.result()

--- a/examples/policy_example.py
+++ b/examples/policy_example.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from parslet.core import DAG, DAGRunner, ParsletFuture, parslet_task
+from parslet.core.policy import AdaptivePolicy
+
+
+@parslet_task
+def work() -> None:
+    """A tiny task used to demonstrate AdaptivePolicy."""
+    print("task running")
+
+
+def main() -> list[ParsletFuture]:
+    dag = DAG()
+    fut = work()
+    dag.build_dag([fut])
+    policy = AdaptivePolicy(max_workers=4)
+    DAGRunner(policy=policy).run(dag)
+    return [fut]

--- a/examples/tools/plot_stats.py
+++ b/examples/tools/plot_stats.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+def ascii_heatmap(path: str) -> None:
+    with open(path, encoding="utf-8") as fh:
+        data: dict[str, Any] = json.load(fh)
+    times: dict[str, float] = data.get("task_execution_times", {})
+    if not times:
+        print("no timing data found")
+        return
+    max_time = max(times.values()) or 1.0
+    for task, t in times.items():
+        bar = "#" * max(1, int(t / max_time * 40))
+        print(f"{task:20} {bar} {t:.2f}s")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: python plot_stats.py stats.json")
+        raise SystemExit(1)
+    ascii_heatmap(sys.argv[1])


### PR DESCRIPTION
## Summary
- add minimal caching, policy, monitor, and compatibility examples
- document AdaptivePolicy, caching, monitoring and stats export
- link README feature bullets to detailed docs

## Testing
- `ruff check examples/cached_task.py examples/policy_example.py examples/tools/plot_stats.py examples/compat/parsl_demo.py examples/compat/dask_demo.py`
- `black examples/cached_task.py examples/policy_example.py examples/tools/plot_stats.py examples/compat/parsl_demo.py examples/compat/dask_demo.py`
- `mypy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac7b2ecd9083338d970405d459e65b