### PR TITLE
Add Parslet landing page with docs CTA and features

### DIFF
--- a/.github/workflows/gh-pages-linkcheck.yml
+++ b/.github/workflows/gh-pages-linkcheck.yml
@@ -1,0 +1,15 @@
+name: Link Check (gh-pages)
+on:
+  push:
+    branches: [ gh-pages ]
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: --verbose --no-progress --exclude-mailto .
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,91 @@
+:root {
+  --bg: #ffffff;
+  --fg: #1b1b1d;
+  --muted: #5b5b63;
+  --primary: #4e2a84; /* purple */
+  --accent: #00a3e0;  /* blue */
+  --secondary: #0b7a75; /* teal/green */
+  --card: #f6f6f8;
+  --ring: #8aa9ff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #101114;
+    --fg: #eaeaf0;
+    --muted: #a0a1a8;
+    --card: #16181d;
+  }
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--bg);
+  color: var(--fg);
+  font: 16px/1.55 system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+.site-header {
+  position: sticky; top: 0; z-index: 10;
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 1rem; padding: .8rem 1rem; background: var(--bg); border-bottom: 1px solid #e7e7ec1a;
+}
+.brand { display: flex; align-items: center; gap: .6rem; font-weight: 700; color: var(--fg); }
+.brand img { display: block; }
+.nav { display: flex; gap: .8rem; align-items: center; }
+.nav a { color: var(--fg); opacity: .85; }
+.nav a:hover { opacity: 1; }
+
+.btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 10px; padding: .65rem .9rem; font-weight: 600; border: 1px solid transparent;
+}
+.btn.primary { background: var(--primary); color: #fff; }
+.btn.secondary { background: var(--card); color: var(--fg); }
+.btn.ghost { border: 1px solid var(--muted); color: var(--fg); }
+.btn:hover { filter: brightness(1.06); text-decoration: none; }
+
+.hero {
+  padding: 3.5rem 1rem 2.5rem; text-align: center; max-width: 980px; margin: 0 auto;
+}
+.hero .badge {
+  display: inline-block; margin-bottom: .75rem; font-size: .9rem;
+  background: linear-gradient(90deg, var(--accent), var(--secondary));
+  -webkit-background-clip: text; background-clip: text; color: transparent;
+  font-weight: 800;
+}
+.hero h1 { font-size: clamp(1.8rem, 3.5vw, 3rem); margin: .3rem 0 .6rem; }
+.hero .sub { color: var(--muted); max-width: 760px; margin: 0 auto 1.1rem; }
+.hero .cta { display: flex; gap: .8rem; justify-content: center; flex-wrap: wrap; }
+
+.why, .features, .quickstart, .interop, .termux { padding: 2rem 1rem; max-width: 1050px; margin: 0 auto; }
+h2 { font-size: 1.6rem; margin: 0 0 1rem; }
+
+.why-grid, .grid {
+  display: grid; gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+.card {
+  background: var(--card); padding: 1rem; border-radius: 12px; border: 1px solid #e7e7ec1a;
+}
+.card h3, .card h4 { margin: 0 0 .4rem; }
+
+.codeblock { position: relative; }
+pre {
+  margin: .6rem 0 1rem; padding: .9rem 1rem;
+  background: #0f1221; color: #e7e7ff;
+  border-radius: 12px; overflow: auto; border: 1px solid #2b3259;
+}
+code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace; }
+
+.site-footer {
+  padding: 2rem 1rem; text-align: center; color: var(--muted);
+  border-top: 1px solid #e7e7ec1a; margin-top: 2rem;
+}
+
+/* focus ring */
+:focus-visible { outline: 3px solid var(--ring); outline-offset: 2px; border-radius: 6px; }

--- a/assets/img/parslet-logo.svg
+++ b/assets/img/parslet-logo.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="60" viewBox="0 0 240 60" role="img" aria-label="Parslet logo">
+  <!-- Bot -->
+  <g transform="translate(6,6)">
+    <rect x="0" y="10" rx="10" ry="10" width="48" height="36" fill="#4e2a84"/>
+    <circle cx="24" cy="16" r="8" fill="#00a3e0"/>
+    <circle cx="24" cy="16" r="3" fill="#101114"/>
+    <rect x="18" y="30" width="12" height="6" rx="3" fill="#0b7a75"/>
+    <line x1="24" y1="0" x2="24" y2="8" stroke="#4e2a84" stroke-width="3" />
+    <circle cx="24" cy="0" r="3" fill="#00a3e0"/>
+    <!-- Arms -->
+    <line x1="4" y1="28" x2="-4" y2="22" stroke="#4e2a84" stroke-width="3" />
+    <line x1="44" y1="28" x2="52" y2="22" stroke="#4e2a84" stroke-width="3" />
+    <!-- Juggling dots -->
+    <circle cx="-2" cy="16" r="3" fill="#0b7a75"/>
+    <circle cx="24" cy="-6" r="3" fill="#00a3e0"/>
+    <circle cx="50" cy="16" r="3" fill="#4e2a84"/>
+  </g>
+  <!-- Wordmark -->
+  <g transform="translate(72,38)" fill="#4e2a84" font-family="Segoe UI, Roboto, Ubuntu, sans-serif">
+    <text font-size="28" font-weight="700">Parslet</text>
+  </g>
+</svg>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,52 @@
+(function () {
+  // Year
+  const y = document.getElementById('year');
+  if (y) y.textContent = new Date().getFullYear();
+
+  // Theme toggle
+  const btn = document.getElementById('themeToggle');
+  const apply = (m) => {
+    if (m === 'light') document.documentElement.dataset.theme = 'light';
+    else if (m === 'dark') document.documentElement.dataset.theme = 'dark';
+    else document.documentElement.dataset.theme = '';
+    localStorage.setItem('parslet-theme', m);
+  };
+  const current = localStorage.getItem('parslet-theme') || 'system';
+  apply(current);
+  if (btn) {
+    btn.addEventListener('click', () => {
+      const v = localStorage.getItem('parslet-theme') || 'system';
+      const next = v === 'light' ? 'dark' : v === 'dark' ? 'system' : 'light';
+      apply(next);
+      btn.textContent = next === 'dark' ? '☀' : '☾';
+    });
+  }
+
+  // Smooth anchor scroll
+  document.querySelectorAll('a[href^="#"]').forEach(a => {
+    a.addEventListener('click', e => {
+      const id = a.getAttribute('href').slice(1);
+      const el = document.getElementById(id);
+      if (el) {
+        e.preventDefault();
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    });
+  });
+
+  // Copy buttons for code blocks
+  document.querySelectorAll('pre').forEach((pre) => {
+    const btn = document.createElement('button');
+    btn.textContent = 'Copy';
+    btn.className = 'btn secondary';
+    btn.style.position = 'absolute';
+    btn.style.top = '6px';
+    btn.style.right = '6px';
+    btn.addEventListener('click', async () => {
+      const code = pre.innerText;
+      try { await navigator.clipboard.writeText(code); btn.textContent = 'Copied!'; setTimeout(()=>btn.textContent='Copy',1200); }
+      catch { btn.textContent = 'Copy failed'; setTimeout(()=>btn.textContent='Copy',1200); }
+    });
+    pre.parentNode.insertBefore(btn, pre);
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -1,215 +1,142 @@
-
-
-<!DOCTYPE html>
-<html class="writer-html5" lang="en" data-content_root="./">
+<!doctype html>
+<html lang="en">
 <head>
-  <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Welcome to Parslet &mdash; Parslet 0.5.0 documentation</title>
-      <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=b86133f3" />
-      <link rel="stylesheet" type="text/css" href="_static/css/theme.css?v=e59714d7" />
-
-  
-      <script src="_static/jquery.js?v=5d32c60e"></script>
-      <script src="_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="_static/documentation_options.js?v=1dd76d02"></script>
-      <script src="_static/doctools.js?v=9bcbadda"></script>
-      <script src="_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="_static/js/theme.js"></script>
-    <link rel="index" title="Index" href="genindex.html" />
-    <link rel="search" title="Search" href="search.html" />
-    <link rel="next" title="Introduction: What is Parslet, Really?" href="introduction.html" /> 
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Parslet · Parallel workflows for low‑resource devices</title>
+  <meta name="description" content="Parslet is a tiny Python workflow engine with DAGs, adaptive battery‑aware scheduling, and Termux/Android support.">
+  <meta property="og:title" content="Parslet" />
+  <meta property="og:description" content="Parallel workflows for low‑resource devices. Battery‑aware, offline‑first, and Parsl/Dask‑friendly." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://kanegraffiti.github.io/Parslet/" />
+  <meta name="twitter:card" content="summary" />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 16 16%22><circle cx=%228%22 cy=%228%22 r=%227%22 fill=%22%234e2a84%22/></svg>">
+  <link rel="stylesheet" href="assets/css/style.css" />
 </head>
+<body>
+<header class="site-header">
+  <a class="brand" href="#top">
+    <img src="assets/img/parslet-logo.svg" alt="Parslet logo" height="36" />
+    <span>Parslet</span>
+  </a>
+  <nav class="nav">
+    <a href="#features">Features</a>
+    <a href="#quickstart">Quickstart</a>
+    <a href="#interop">Interop</a>
+    <a href="#termux">Termux</a>
+    <a href="https://parslet.readthedocs.io/en/latest/" target="_blank" rel="noopener">Docs</a>
+    <a href="https://github.com/Kanegraffiti/Parslet" target="_blank" rel="noopener">GitHub</a>
+    <button id="themeToggle" class="btn secondary" aria-label="Toggle theme">☾</button>
+  </nav>
+</header>
 
-<body class="wy-body-for-nav"> 
-  <div class="wy-grid-for-nav">
-    <nav data-toggle="wy-nav-shift" class="wy-nav-side">
-      <div class="wy-side-scroll">
-        <div class="wy-side-nav-search" >
+<main id="top">
+  <section class="hero">
+    <div class="badge">Speaking at ParslFest 2025</div>
+    <h1>Parallel workflows for low‑resource devices</h1>
+    <p class="sub">
+      A tiny Python DAG engine that thrives on phones, Pis, and edge devices—offline‑first and battery‑aware.
+    </p>
+    <div class="cta">
+      <a class="btn primary" href="https://parslet.readthedocs.io/en/latest/" target="_blank" rel="noopener">Read the Docs</a>
+      <a class="btn ghost" href="https://github.com/Kanegraffiti/Parslet" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </section>
 
-          
-          
-          <a href="#" class="icon icon-home">
-            Parslet
-          </a>
-<div role="search">
-  <form id="rtd-search-form" class="wy-form" action="search.html" method="get">
-    <input type="text" name="q" placeholder="Search docs" aria-label="Search docs" />
-    <input type="hidden" name="check_keywords" value="yes" />
-    <input type="hidden" name="area" value="default" />
-  </form>
-</div>
-        </div><div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="Navigation menu">
-              <p class="caption" role="heading"><span class="caption-text">User Guide</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="introduction.html">Introduction: What is Parslet, Really?</a></li>
-<li class="toctree-l1"><a class="reference internal" href="install.html">Parslet Installation Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="usage.html">Usage: Your First Parslet Workflow</a></li>
-<li class="toctree-l1"><a class="reference internal" href="examples.html">Parslet Recipes: Real-World Examples</a></li>
-<li class="toctree-l1"><a class="reference internal" href="use_cases.html">Real-World Use Cases</a></li>
-<li class="toctree-l1"><a class="reference internal" href="cli.html">Your Remote Control: The Parslet CLI</a></li>
-<li class="toctree-l1"><a class="reference internal" href="tasks.html">What Are Parslet Tasks?</a></li>
-<li class="toctree-l1"><a class="reference internal" href="battery_mode.html">Running on Fumes? Use Battery-Saver Mode!</a></li>
-<li class="toctree-l1"><a class="reference internal" href="exporting.html">Exporting</a></li>
-</ul>
-<p class="caption" role="heading"><span class="caption-text">Architecture</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="architecture.html">The Parslet Engine: How It All Fits Together</a></li>
-<li class="toctree-l1"><a class="reference internal" href="security.html">Security Sentries</a></li>
-<li class="toctree-l1"><a class="reference internal" href="compatibility.html">Compatibility Layer</a></li>
-</ul>
-<p class="caption" role="heading"><span class="caption-text">Development</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="contributing.html">Contributing</a></li>
-<li class="toctree-l1"><a class="reference internal" href="testing.html">Testing</a></li>
-<li class="toctree-l1"><a class="reference internal" href="challenge.html">Our Parslet Showcase</a></li>
-<li class="toctree-l1"><a class="reference internal" href="benchmark_results.html">How Fast Is Parslet? (Our Benchmark Results)</a></li>
-</ul>
+  <section class="why">
+    <div class="why-grid">
+      <div class="card"><h3>Offline‑first</h3><p>Run workflows without connectivity. Great for field work and clinics.</p></div>
+      <div class="card"><h3>Battery‑aware</h3><p>Adaptive scheduling that scales down when power is scarce.</p></div>
+      <div class="card"><h3>Tiny & Pythonic</h3><p>Just write functions. Parslet handles dependencies as a DAG.</p></div>
+    </div>
+  </section>
 
-        </div>
-      </div>
-    </nav>
+  <section id="features" class="features">
+    <h2>Key features</h2>
+    <div class="grid">
+      <div class="card"><h4>DAG, not ceremony</h4><p>Compose tasks, get futures, return a final list—done.</p></div>
+      <div class="card"><h4>Adaptive scheduling</h4><p>Battery‑aware policy with sensible defaults and CLI control.</p></div>
+      <div class="card"><h4>Stats & monitor</h4><p>Export run stats and watch progress live in your terminal.</p></div>
+      <div class="card"><h4>Deterministic caching</h4><p>Opt‑in content‑hash caching for expensive pure tasks.</p></div>
+      <div class="card"><h4>Parsl & Dask interop</h4><p>Experimental import/export keeps you portable.</p></div>
+      <div class="card"><h4>Termux native</h4><p>Friendly on Android; designed for constrained devices.</p></div>
+    </div>
+  </section>
 
-    <section data-toggle="wy-nav-shift" class="wy-nav-content-wrap"><nav class="wy-nav-top" aria-label="Mobile navigation menu" >
-          <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-          <a href="#">Parslet</a>
-      </nav>
+  <section id="quickstart" class="quickstart">
+    <h2>Quickstart</h2>
 
-      <div class="wy-nav-content">
-        <div class="rst-content">
-          <div role="navigation" aria-label="Page navigation">
-  <ul class="wy-breadcrumbs">
-      <li><a href="#" class="icon icon-home" aria-label="Home"></a></li>
-      <li class="breadcrumb-item active">Welcome to Parslet</li>
-      <li class="wy-breadcrumbs-aside">
-            <a href="_sources/index.rst.txt" rel="nofollow"> View page source</a>
-      </li>
-  </ul>
-  <hr/>
-</div>
-          <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
-           <div itemprop="articleBody">
-             
-  <section id="welcome-to-parslet">
-<h1>Welcome to Parslet<a class="headerlink" href="#welcome-to-parslet" title="Link to this heading"></a></h1>
-<div class="toctree-wrapper compound">
-<p class="caption" role="heading"><span class="caption-text">User Guide</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="introduction.html">Introduction: What is Parslet, Really?</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="introduction.html#let-s-start-with-a-story">Let’s Start with a Story</a></li>
-<li class="toctree-l2"><a class="reference internal" href="introduction.html#what-problem-does-parslet-solve">What Problem Does Parslet Solve?</a></li>
-<li class="toctree-l2"><a class="reference internal" href="introduction.html#the-three-big-ideas-in-parslet">The Three Big Ideas in Parslet</a></li>
-<li class="toctree-l2"><a class="reference internal" href="introduction.html#how-is-parslet-different-from-the-big-guys">How is Parslet Different from the Big Guys?</a></li>
-</ul>
-</li>
-<li class="toctree-l1"><a class="reference internal" href="install.html">Parslet Installation Guide</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="install.html#recommended-installation-from-pypi">Recommended Installation (from PyPI)</a></li>
-<li class="toctree-l2"><a class="reference internal" href="install.html#installation-for-developers-from-source">Installation for Developers (from Source)</a></li>
-</ul>
-</li>
-<li class="toctree-l1"><a class="reference internal" href="usage.html">Usage: Your First Parslet Workflow</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="usage.html#defining-your-tasks">Defining Your Tasks</a></li>
-<li class="toctree-l2"><a class="reference internal" href="usage.html#running-your-workflow">Running Your Workflow</a></li>
-<li class="toctree-l2"><a class="reference internal" href="usage.html#being-smart-with-resources">Being Smart with Resources</a></li>
-</ul>
-</li>
-<li class="toctree-l1"><a class="reference internal" href="examples.html">Parslet Recipes: Real-World Examples</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="examples.html#the-hello-world-of-parslet">1. The “Hello World” of Parslet</a></li>
-<li class="toctree-l2"><a class="reference internal" href="examples.html#the-offline-photo-filter">2. The Offline Photo Filter</a></li>
-<li class="toctree-l2"><a class="reference internal" href="examples.html#the-offline-text-cleaner">3. The Offline Text Cleaner</a></li>
-<li class="toctree-l2"><a class="reference internal" href="examples.html#the-video-frame-extractor">4. The Video Frame Extractor</a></li>
-<li class="toctree-l2"><a class="reference internal" href="examples.html#the-rad-parslet-medical-imaging-pipeline">5. The RAD-Parslet Medical Imaging Pipeline</a></li>
-<li class="toctree-l2"><a class="reference internal" href="examples.html#edge-mcu-sensor-data-processor">6. Edge MCU Sensor Data Processor</a></li>
-</ul>
-</li>
-<li class="toctree-l1"><a class="reference internal" href="use_cases.html">Real-World Use Cases</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="use_cases.html#remote-telecom-tower-monitoring">Remote Telecom Tower Monitoring</a></li>
-<li class="toctree-l2"><a class="reference internal" href="use_cases.html#solar-site-optimization">Solar Site Optimization</a></li>
-</ul>
-</li>
-<li class="toctree-l1"><a class="reference internal" href="cli.html">Your Remote Control: The Parslet CLI</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="cli.html#the-buttons-on-your-remote-control">The Buttons on Your Remote Control</a></li>
-<li class="toctree-l2"><a class="reference internal" href="cli.html#an-example">An Example</a></li>
-</ul>
-</li>
-<li class="toctree-l1"><a class="reference internal" href="tasks.html">What Are Parslet Tasks?</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="tasks.html#a-simple-example">A Simple Example</a></li>
-<li class="toctree-l2"><a class="reference internal" href="tasks.html#what-happens-when-things-go-wrong-error-handling">What Happens When Things Go Wrong? (Error Handling)</a></li>
-</ul>
-</li>
-<li class="toctree-l1"><a class="reference internal" href="battery_mode.html">Running on Fumes? Use Battery-Saver Mode!</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="battery_mode.html#how-does-it-work">How Does It Work?</a></li>
-<li class="toctree-l2"><a class="reference internal" href="battery_mode.html#how-do-i-turn-it-on">How Do I Turn It On?</a></li>
-<li class="toctree-l2"><a class="reference internal" href="battery_mode.html#what-if-i-still-need-to-go-a-little-faster">What if I Still Need to Go a Little Faster?</a></li>
-</ul>
-</li>
-<li class="toctree-l1"><a class="reference internal" href="exporting.html">Exporting</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="exporting.html#example">Example</a></li>
-</ul>
-</li>
-</ul>
-</div>
-<div class="toctree-wrapper compound">
-<p class="caption" role="heading"><span class="caption-text">Architecture</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="architecture.html">The Parslet Engine: How It All Fits Together</a></li>
-<li class="toctree-l1"><a class="reference internal" href="security.html">Security Sentries</a></li>
-<li class="toctree-l1"><a class="reference internal" href="compatibility.html">Compatibility Layer</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="compatibility.html#dask-compatibility">Dask compatibility</a></li>
-<li class="toctree-l2"><a class="reference internal" href="compatibility.html#parsl-compatibility">Parsl compatibility</a></li>
-</ul>
-</li>
-</ul>
-</div>
-<div class="toctree-wrapper compound">
-<p class="caption" role="heading"><span class="caption-text">Development</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="contributing.html">Contributing</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="contributing.html#style-guide">Style guide</a></li>
-<li class="toctree-l2"><a class="reference internal" href="contributing.html#development-workflow">Development workflow</a></li>
-</ul>
-</li>
-<li class="toctree-l1"><a class="reference internal" href="testing.html">Testing</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="testing.html#running-the-tests">Running the tests</a></li>
-<li class="toctree-l2"><a class="reference internal" href="testing.html#pre-commit-hooks">Pre-commit hooks</a></li>
-<li class="toctree-l2"><a class="reference internal" href="testing.html#continuous-integration">Continuous integration</a></li>
-</ul>
-</li>
-<li class="toctree-l1"><a class="reference internal" href="challenge.html">Our Parslet Showcase</a></li>
-<li class="toctree-l1"><a class="reference internal" href="benchmark_results.html">How Fast Is Parslet? (Our Benchmark Results)</a></li>
-</ul>
-</div>
-</section>
-
-
-           </div>
-          </div>
-          <footer><div class="rst-footer-buttons" role="navigation" aria-label="Footer">
-        <a href="introduction.html" class="btn btn-neutral float-right" title="Introduction: What is Parslet, Really?" accesskey="n" rel="next">Next <span class="fa fa-arrow-circle-right" aria-hidden="true"></span></a>
+    <div class="codeblock">
+<pre><code class="language-bash"># Install from PyPI
+pip install parslet</code></pre>
     </div>
 
-  <hr/>
+    <div class="codeblock">
+<pre><code class="language-python">from parslet import parslet_task, ParsletFuture, DAG, DAGRunner
+from typing import List
 
-  <div role="contentinfo">
-    <p>&#169; Copyright 2025, Parslet Team.</p>
-  </div>
+@parslet_task
+def hello(name: str) -&gt; str:
+    return f"Hello, {name}!"
 
-  Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a
-    <a href="https://github.com/readthedocs/sphinx_rtd_theme">theme</a>
-    provided by <a href="https://readthedocs.org">Read the Docs</a>.
-   
+@parslet_task
+def loud(text: str) -&gt; str:
+    return text.upper()
 
+def main() -&gt; List[ParsletFuture]:
+    a = hello("Parslet")
+    b = loud(a)
+    return [b]
+
+if __name__ == "__main__":
+    dag = DAG()
+    dag.add_tasks(*main())
+    DAGRunner(dag).run()</code></pre>
+    </div>
+
+    <p>Run it:</p>
+    <div class="codeblock">
+<pre><code class="language-bash">parslet run my_workflow.py</code></pre>
+    </div>
+
+    <p>Export a DAG image (requires graphviz):</p>
+    <div class="codeblock">
+<pre><code class="language-bash">parslet run my_workflow.py --export-png dag.png</code></pre>
+    </div>
+  </section>
+
+  <section id="interop" class="interop">
+    <h2>Interop (experimental)</h2>
+    <p>Convert simple scripts to move between ecosystems.</p>
+    <div class="codeblock">
+<pre><code class="language-bash"># Parsl → Parslet
+parslet convert --from-parsl app.py --to-parslet out.py
+
+# Dask → Parslet
+parslet convert --from-dask dask.py --to-parslet out.py</code></pre>
+    </div>
+  </section>
+
+  <section id="termux" class="termux">
+    <h2>Android / Termux</h2>
+    <div class="codeblock">
+<pre><code class="language-bash">pkg install python
+pip install parslet
+termux-setup-storage
+parslet run examples/battery_aware_demo.py</code></pre>
+    </div>
+  </section>
+</main>
+
+<footer class="site-footer">
+  <p>© <span id="year"></span> Parslet. MIT License.</p>
+  <p>
+    <a href="https://parslet.readthedocs.io/en/latest/" target="_blank" rel="noopener">Docs</a> ·
+    <a href="https://github.com/Kanegraffiti/Parslet" target="_blank" rel="noopener">GitHub</a> ·
+    <a href="https://github.com/Kanegraffiti/Parslet/blob/main/LICENSE" target="_blank" rel="noopener">License</a>
+  </p>
 </footer>
-        </div>
-      </div>
-    </section>
-  </div>
-  <script>
-      jQuery(function () {
-          SphinxRtdTheme.Navigation.enable(true);
-      });
-  </script> 
 
+<script src="assets/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add lightweight Parslet landing page with hero, feature grid, quickstart and interop sections
- implement dark/light theme styles and JS theme toggle plus code-copy helpers
- add link-check workflow for gh-pages

## Testing
- `node --check assets/js/main.js && echo "JS syntax OK"`
- `npx htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68ac858143608333a0997300d9751d64