### PR TITLE
Improve site responsiveness and theme behavior

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -7,6 +7,7 @@
   --secondary: #0b7a75; /* teal/green */
   --card: #f6f6f8;
   --ring: #8aa9ff;
+  --flow: #f6f6f8;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -15,6 +16,7 @@
     --fg: #eaeaf0;
     --muted: #a0a1a8;
     --card: #16181d;
+    --flow: #272a31;
   }
 }
 
@@ -28,6 +30,7 @@ body {
 
 a { color: var(--accent); text-decoration: none; }
 a:hover { text-decoration: underline; }
+img { max-width: 100%; height: auto; }
 
 .site-header {
   position: sticky; top: 0; z-index: 10;
@@ -39,6 +42,12 @@ a:hover { text-decoration: underline; }
 .nav { display: flex; gap: .8rem; align-items: center; }
 .nav a { color: var(--fg); opacity: .85; }
 .nav a:hover { opacity: 1; }
+
+@media (max-width: 600px) {
+  .site-header { flex-direction: column; align-items: center; }
+  .nav { flex-wrap: wrap; justify-content: center; }
+  .nav a, .nav button { flex: 1 1 100%; text-align: center; }
+}
 
 .btn {
   display: inline-flex; align-items: center; justify-content: center;
@@ -107,6 +116,8 @@ code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation M
   background: linear-gradient(0deg, transparent, transparent);
   border-radius: 10px; border: 1px solid #e7e7ec1a; padding: .4rem;
 }
+.flow-svg .b { fill: none; stroke: currentColor; stroke-width: 2; }
+.flow-svg .n { fill: var(--flow); stroke: currentColor; }
 
 /* Animations */
 @media (prefers-reduced-motion: no-preference) {
@@ -128,6 +139,7 @@ code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation M
   --fg: #1b1b1d;
   --muted: #5b5b63;
   --card: #f6f6f8;
+  --flow: #f6f6f8;
 }
 :root[data-theme="dark"] {
   color-scheme: dark;
@@ -135,4 +147,5 @@ code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation M
   --fg: #eaeaf0;
   --muted: #a0a1a8;
   --card: #16181d;
+  --flow: #272a31;
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -12,9 +12,10 @@
     root.dataset.theme = (mode === 'system') ? '' : mode;
     localStorage.setItem('parslet-theme', mode);
     if (btn) {
-      btn.setAttribute('aria-pressed', mode !== 'system');
+      const isDark = mode === 'dark' || (mode === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+      btn.setAttribute('aria-pressed', isDark);
       btn.title = `Theme: ${mode}`;
-      btn.textContent = mode === 'light' ? '☀' : mode === 'dark' ? '☾' : 'A';
+      btn.textContent = isDark ? '☾' : '☀';
     }
   }
   const saved = localStorage.getItem('parslet-theme') || 'system';

--- a/index.html
+++ b/index.html
@@ -91,12 +91,6 @@
         <div class="flow" id="flow-battery" hidden>
           <!-- simple block flow -->
           <svg viewBox="0 0 420 120" class="flow-svg" role="img" aria-label="Battery aware flow">
-            <defs>
-              <style>
-                .b { fill:none; stroke:currentColor; stroke-width:2; }
-                .n { fill:var(--card); stroke:currentColor; }
-              </style>
-            </defs>
             <rect class="n" x="10" y="30" rx="6" width="110" height="60"></rect>
             <text x="65" y="65" text-anchor="middle">check_battery</text>
             <path class="b" d="M120,60 L170,60"></path>
@@ -123,7 +117,6 @@
         <button class="btn secondary flow-toggle" data-target="flow-rad">View flow</button>
         <div class="flow" id="flow-rad" hidden>
           <svg viewBox="0 0 480 140" class="flow-svg" role="img" aria-label="RAD flow">
-            <defs><style>.b{fill:none;stroke:currentColor;stroke-width:2}.n{fill:var(--card);stroke:currentColor}</style></defs>
             <rect class="n" x="10"  y="40" rx="6" width="90"  height="60"></rect>
             <text x="55" y="75" text-anchor="middle">ingest</text>
             <path class="b" d="M100,70 L140,70"></path>
@@ -155,7 +148,6 @@
         <button class="btn secondary flow-toggle" data-target="flow-edge">View flow</button>
         <div class="flow" id="flow-edge" hidden>
           <svg viewBox="0 0 420 120" class="flow-svg" role="img" aria-label="Edge sensor flow">
-            <defs><style>.b{fill:none;stroke:currentColor;stroke-width:2}.n{fill:var(--card);stroke:currentColor}</style></defs>
             <rect class="n" x="10" y="30" rx="6" width="90" height="60"></rect>
             <text x="55" y="65" text-anchor="middle">read</text>
             <path class="b" d="M100,60 L150,60"></path>
@@ -178,7 +170,6 @@
         <button class="btn secondary flow-toggle" data-target="flow-text">View flow</button>
         <div class="flow" id="flow-text" hidden>
           <svg viewBox="0 0 420 120" class="flow-svg" role="img" aria-label="Text cleaner flow">
-            <defs><style>.b{fill:none;stroke:currentColor;stroke-width:2}.n{fill:var(--card);stroke:currentColor}</style></defs>
             <rect class="n" x="10" y="30" rx="6" width="90" height="60"></rect>
             <text x="55" y="65" text-anchor="middle">load</text>
             <path class="b" d="M100,60 L150,60"></path>
@@ -201,7 +192,6 @@
         <button class="btn secondary flow-toggle" data-target="flow-image">View flow</button>
         <div class="flow" id="flow-image" hidden>
           <svg viewBox="0 0 420 120" class="flow-svg" role="img" aria-label="Image filter flow">
-            <defs><style>.b{fill:none;stroke:currentColor;stroke-width:2}.n{fill:var(--card);stroke:currentColor}</style></defs>
             <rect class="n" x="10" y="30" rx="6" width="90" height="60"></rect>
             <text x="55" y="65" text-anchor="middle">load</text>
             <path class="b" d="M100,60 L150,60"></path>
@@ -224,7 +214,6 @@
         <button class="btn secondary flow-toggle" data-target="flow-interop">View flow</button>
         <div class="flow" id="flow-interop" hidden>
           <svg viewBox="0 0 480 120" class="flow-svg" role="img" aria-label="Interop flow">
-            <defs><style>.b{fill:none;stroke:currentColor;stroke-width:2}.n{fill:var(--card);stroke:currentColor}</style></defs>
             <rect class="n" x="20" y="30" rx="6" width="110" height="60"></rect>
             <text x="75" y="65" text-anchor="middle">parsl app</text>
             <path class="b" d="M130,60 L180,60"></path>


### PR DESCRIPTION
## Summary
- make navigation responsive for small screens
- ensure flow diagrams respect theme colors
- fix theme toggle icon flicker

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`
- `pre-commit run --files assets/js/main.js assets/css/style.css index.html` *(fails: pre-commit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aefdde08688333ac01c563955dfc1c