### PR TITLE
Expand Parsl and Dask interoperability docs

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -52,20 +52,30 @@ When you run this with `parslet run my_recipe.py`, Parslet will read the file, s
 
 ### Step 3: Playing Well with the Big Kids (Parsl & Dask)
 
-One of Parslet's superpowers is that it helps you "graduate" to bigger tools when you need more power.
+One of Parslet's superpowers is that it helps you "graduate" to bigger tools when you need more power. Parslet ships with a compatibility layer and a source-code converter so that your work can move in either direction.
 
--   **Using Parsl:** You can take your Parslet recipe and run it with its big brother, Parsl. We have a special helper tool that makes this easy. It's great for when you get access to a powerful server and need to run your recipe there.
-
--   **Converting from Parsl or Dask:** Did someone give you a recipe that was written for the "big kid" tools? No problem! Parslet has a command-line converter that can translate Parsl or Dask scripts into Parslet scripts for you.
+-   **Using Parsl:** When a workflow outgrows your laptop, translate it to a Parsl script and run it on a cluster.
 
     ```bash
-    # To convert a Parsl script:
-    parslet convert --from-parsl their_cool_script.py
-
-    # To convert a Dask script:
-    parslet convert --from-dask another_cool_script.py
+    # Convert a Parslet recipe to Parsl
+    parslet convert --from-parslet my_recipe.py --to-parsl my_recipe_parsl.py
+    python my_recipe_parsl.py  # executed with a Parsl executor
     ```
-    This will create a new `_parslet.py` file that you can run right away!
+
+-   **Converting from Parsl or Dask:** If you are handed a Parsl or Dask workflow, Parslet can import it so you can run it offline.
+
+    ```bash
+    # Parsl -> Parslet
+    parslet convert --from-parsl their_cool_script.py --to-parslet local_script.py
+
+    # Dask -> Parslet
+    parslet convert --from-dask another_cool_script.py --to-parslet local_script.py
+
+    # You can also export back to Dask if needed
+    parslet convert --from-parslet my_recipe.py --to-dask my_recipe_dask.py
+    ```
+
+    Each command performs an AST rewrite and produces a new file with a `_parslet.py`, `_parsl.py`, or `_dask.py` suffix. The converter currently supports pure Python `@python_app` tasks and `dask.delayed` graphs and is intended for local execution—complex data staging or provider settings are out of scope.
 
 ### Never Lose Your Work! (Resuming Recipes)
 

--- a/docs/source/compatibility.rst
+++ b/docs/source/compatibility.rst
@@ -1,28 +1,80 @@
 Compatibility Layer
 ===================
 
-Parslet includes lightweight adapters allowing you to reuse familiar
-Dask and Parsl style syntax. The :mod:`parslet.compat` package provides
-AST transformers for converting existing scripts as well as runtime
-shims that mimic a subset of each API.
+Parslet includes a small compatibility layer so that simple Parsl and Dask
+workflows can be exchanged with Parslet. It provides two mechanisms:
+
+* **Runtime shims** that mimic portions of each library's API.
+* **Source-to-source converters** implemented as abstract syntax tree (AST)
+  transforms.
+
+.. note::
+
+   These features are experimental and focus on pure Python code intended
+   for local execution. Data staging directives, provider configuration and
+   advanced Dask scheduler settings are not translated.
 
 Dask compatibility
 ------------------
-Use ``parslet.compat.delayed`` and ``parslet.compat.compute`` in place
-of Dask's ``dask.delayed`` and ``dask.compute``.  You can also convert a
-script programmatically:
+
+Drop-in replacements for :func:`dask.delayed` and :func:`dask.compute` live in
+:mod:`parslet.compat`:
+
+.. code-block:: python
+
+   from parslet.compat import delayed, compute
+
+   @delayed
+   def add(x, y):
+       return x + y
+
+   total = compute(add(1, 2))[0]
+
+Existing Dask scripts can be translated either programmatically or via the CLI:
 
 .. code-block:: python
 
    from parslet.compat import convert_dask_to_parslet
 
-   new_code = convert_dask_to_parslet(open("workflow.py").read())
+   rewritten = convert_dask_to_parslet(open("workflow.py").read())
+
+.. code-block:: bash
+
+   parslet convert --from-dask workflow.py --to-parslet workflow_parslet.py
+
+To move in the opposite direction:
+
+.. code-block:: bash
+
+   parslet convert --from-parslet recipe.py --to-dask recipe_dask.py
 
 Parsl compatibility
 -------------------
-``parslet.compat.python_app`` and ``parslet.compat.bash_app`` wrap
-functions similar to Parsl's decorators.  The ``convert_parsl_to_parslet``
-function converts source code in bulk.
 
-See ``examples/`` for scripts that mirror typical Dask and Parsl DAGs
-running under Parslet.
+Parsl interoperability mirrors the Dask bridge. Parslet provides
+``python_app`` and ``bash_app`` decorators as well as conversion utilities.
+
+.. code-block:: python
+
+   from parslet.compat import python_app
+
+   @python_app
+   def hello():
+       return "hi"
+
+.. code-block:: bash
+
+   parslet convert --from-parsl app.py --to-parslet app_parslet.py
+   parslet convert --from-parslet recipe.py --to-parsl recipe_parsl.py
+
+Each exported script recreates the original DAG by rendering every node as a
+Parsl ``@python_app`` and wiring the dependencies.
+
+Caveats
+-------
+
+* Only pure Python task bodies are handled; Bash apps and staging directives are
+  ignored.
+* The generated code targets local execution and requires further tuning for
+  distributed or HPC environments.
+* Always review the converted source before relying on it in production.


### PR DESCRIPTION
## Summary
- flesh out "Playing Well with the Big Kids" section with concrete Parsl/Dask conversion workflows
- add a comprehensive guide to Parsl and Dask compatibility, including runtime shims, CLI conversions and caveats
- mirror the compatibility details in the Sphinx docs

## Testing
- `pre-commit run --files docs/getting_started.md docs/compatibility.md docs/source/compatibility.rst`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af01ac8a688333be1b6a1b26a129f7