### PR TITLE
Enhance responsiveness and add audience map

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -24,9 +24,11 @@ a{color:var(--link);}a:focus{outline:2px dashed var(--teal-500);outline-offset:2
 .container{max-width:72rem;margin:0 auto;padding:0 1rem;}
 .flex-between{display:flex;align-items:center;justify-content:space-between;}
 .nav-list{list-style:none;margin:0;padding:0;display:flex;gap:1rem;align-items:center;}
+.menu-toggle{background:none;border:1px solid var(--fg);border-radius:var(--radius);padding:0.25rem 0.5rem;cursor:pointer;display:none;}
 .nav-link{text-decoration:none;color:var(--fg);} .nav-link:hover{text-decoration:underline;}
 .theme-toggle{background:none;border:1px solid var(--fg);border-radius:var(--radius);padding:0.25rem 0.5rem;cursor:pointer;}
 .site-header{position:sticky;top:0;background:var(--bg);z-index:100;transition:box-shadow var(--transition);} .site-header.scrolled{box-shadow:0 2px 4px rgba(0,0,0,0.1);}
+.site-header .container{position:relative;}
 .hero{background:linear-gradient(135deg,var(--brand-900),var(--brand-700));color:#fff;padding:4rem 0;} .hero .btn{margin-right:0.5rem;}
 .hero-img{justify-self:center;}
 .btn{display:inline-block;padding:0.5rem 1rem;border-radius:var(--radius);text-decoration:none;font-weight:600;transition:background var(--transition),color var(--transition);} 
@@ -56,6 +58,22 @@ a{color:var(--link);}a:focus{outline:2px dashed var(--teal-500);outline-offset:2
 .footer-nav{list-style:none;display:flex;flex-wrap:wrap;gap:1rem;padding:0;margin:0 0 1rem 0;}
 .footer-nav a{color:#fff;text-decoration:none;} .footer-nav a:hover{text-decoration:underline;}
 .small{font-size:0.875rem;}
+.audience-map{height:400px;border-radius:var(--radius);}
 @media(prefers-reduced-motion:reduce){*{animation:none;transition:none;}}
 .reveal{opacity:0;transform:translateY(20px);transition:opacity .6s ease,transform .6s ease;}
 .reveal.visible{opacity:1;transform:none;}
+
+@media(max-width:600px){
+  .nav-list{
+    position:absolute;
+    top:100%;
+    right:1rem;
+    background:var(--bg);
+    flex-direction:column;
+    padding:1rem;
+    border:1px solid var(--muted);
+    display:none;
+  }
+  .nav-list.open{display:flex;}
+  .menu-toggle{display:block;}
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -50,4 +50,30 @@
     });
   },{threshold:0.1});
   document.querySelectorAll('.reveal').forEach(el=>observer.observe(el));
+
+  // mobile navigation toggle
+  const menuToggle = document.getElementById('menu-toggle');
+  const navList = document.querySelector('.nav-list');
+  if(menuToggle && navList){
+    menuToggle.addEventListener('click',()=>{
+      navList.classList.toggle('open');
+    });
+  }
+
+  // audience map
+  const mapEl = document.getElementById('audience-map');
+  if(mapEl && window.L){
+    const map = L.map('audience-map').setView([20,0],2);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{
+      attribution:'&copy; OpenStreetMap contributors'
+    }).addTo(map);
+    const locations = [
+      {coords:[37.7749,-122.4194],label:'San Francisco'},
+      {coords:[51.5074,-0.1278],label:'London'},
+      {coords:[28.6139,77.2090],label:'New Delhi'},
+      {coords:[-23.5505,-46.6333],label:'São Paulo'},
+      {coords:[35.6895,139.6917],label:'Tokyo'}
+    ];
+    locations.forEach(loc=>L.marker(loc.coords).addTo(map).bindPopup(loc.label));
+  }
 })();

--- a/index.html
+++ b/index.html
@@ -8,6 +8,12 @@
   <meta name="description" content="Parslet: pocket-sized parallel workflows for edge devices." />
   <link rel="stylesheet" href="assets/css/prism.min.css" />
   <link rel="stylesheet" href="assets/css/styles.css" />
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    integrity="sha256-sA+e7cN65PFDvghENkuZKOR6zyPDDkLMOVnmtz6dSg0="
+    crossorigin=""
+  />
   <link rel="icon" href="assets/images/logo.svg" type="image/svg+xml"/>
   <meta property="og:title" content="Parslet"/>
   <meta property="og:description" content="Pocket-sized parallel workflows."/>
@@ -30,6 +36,7 @@
   <header class="site-header" id="top">
     <div class="container flex-between">
       <a href="#top" class="logo" aria-label="Parslet home"><img src="assets/images/logo.svg" alt="Parslet logo"/></a>
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle navigation">☰</button>
       <nav aria-label="Main navigation">
         <ul class="nav-list">
           <li><a href="https://parslet.readthedocs.io/en/latest/" target="_blank" rel="noopener" class="nav-link">Docs</a></li>
@@ -145,6 +152,13 @@ parslet run hello_parslet.py</code></pre>
       </div>
     </section>
 
+    <section class="audience" id="audience">
+      <h2 class="container">Android Developer Reach</h2>
+      <div class="container">
+        <div id="audience-map" class="audience-map" aria-label="Map showing distribution of Parslet Android developers"></div>
+      </div>
+    </section>
+
     <section class="interop" id="interop">
       <h2 class="container">Interoperability</h2>
       <div class="container grid-2">
@@ -187,6 +201,12 @@ parslet convert --from-dask dask_workflow.py -o converted_parslet.py</code></pre
   </footer>
 
   <script src="assets/js/prism.min.js" defer></script>
+  <script
+    src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+    integrity="sha256-oHeY9TxVMxWuKE0S8Hk2dwg99R0Mnq+H3DR8HFZn9Oo="
+    crossorigin=""
+    defer
+  ></script>
   <script src="assets/js/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Improve header navigation with mobile-friendly menu
- Add Leaflet-based map showing global Android developer reach
- Include responsive styles for map and navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afc693d8a08333b8c78f2d7b32d04c