### PR TITLE
Improve help and Parsl compatibility

### DIFF
--- a/parslet/cli.py
+++ b/parslet/cli.py
@@ -1,4 +1,6 @@
+import re
 import sys
+import tempfile
 from importlib import import_module
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
@@ -28,16 +30,42 @@ def load_workflow_module(path: str) -> ModuleType:
         mod_name, func_name = path.split(":", 1)
         module = import_module(mod_name)
         if not hasattr(module, func_name):
-            raise ImportError(f"Module '{mod_name}' has no attribute '{func_name}'")
+            msg = f"Module '{mod_name}' does not define '{func_name}'."
+            raise ImportError(msg)
         # Expose the target callable as ``main`` for CLI expectations
         module.main = getattr(module, func_name)  # type: ignore[attr-defined]
         return module
 
     wf_path = Path(path).resolve()
+    if not wf_path.exists():
+        msg = f"Cannot find workflow at '{path}'. Check the path."
+        raise ImportError(msg)
+
+    code = wf_path.read_text(encoding="utf-8")
+    if re.search(r"@\s*(python_app|bash_app)", code):
+        from .compat.parsl_adapter import import_parsl_script
+
+        tmp = tempfile.NamedTemporaryFile(suffix="_parslet.py", delete=False)
+        tmp.close()
+        import_parsl_script(str(wf_path), tmp.name)
+        spec = spec_from_file_location(Path(tmp.name).stem, tmp.name)
+        if spec and spec.loader:
+            module = module_from_spec(spec)
+            sys.modules[Path(tmp.name).stem] = module
+            spec.loader.exec_module(module)
+            module.__converted_from_parsl__ = True
+            module.__original_parsl_path__ = str(wf_path)
+            return module
+        raise ImportError(
+            "Converted Parsl workflow could not be loaded; "
+            "please check the source file."
+        )
+
     spec = spec_from_file_location(wf_path.stem, wf_path)
     if spec and spec.loader:
         module = module_from_spec(spec)
         sys.modules[wf_path.stem] = module
         spec.loader.exec_module(module)
         return module
-    raise ImportError(f"Cannot load workflow module from {path}")
+    msg = f"Unable to load workflow from '{path}'. Ensure it is valid Python."
+    raise ImportError(msg)

--- a/parslet/main_cli.py
+++ b/parslet/main_cli.py
@@ -17,27 +17,60 @@ from .utils import get_parslet_logger
 
 def cli() -> None:
     """Parse command line arguments and dispatch the chosen command."""
-    parser = argparse.ArgumentParser(description="Parslet command line")
+    desc = "Parslet command line - run and convert workflows."
+    parser = argparse.ArgumentParser(
+        description=desc,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     if len(sys.argv) == 1:
         parser.print_help()
         return
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    run_p = sub.add_parser("run", help="Run a workflow")
-    run_p.add_argument("workflow", help="Workflow file path or module:func reference")
-    run_p.add_argument("--monitor", action="store_true", help="Show progress")
-    run_p.add_argument("--battery-mode", action="store_true")
-    run_p.add_argument(
-        "--json-logs", action="store_true", help="Emit logs in JSON format"
+    run_p = sub.add_parser(
+        "run",
+        help="Run a workflow",
+        description="Execute a Parslet workflow file or module reference.",
     )
-    run_p.add_argument("--failsafe-mode", action="store_true")
-    run_p.add_argument("--offline", action="store_true", help="Disable network access")
+    run_p.add_argument(
+        "workflow",
+        help="Workflow file path or module:func reference",
+    )
+    run_p.add_argument(
+        "--monitor",
+        action="store_true",
+        help="Show live task progress during execution",
+    )
+    run_p.add_argument(
+        "--battery-mode",
+        action="store_true",
+        help="Limit workers when system battery is low",
+    )
+    run_p.add_argument(
+        "--json-logs",
+        action="store_true",
+        help="Emit logs in JSON format",
+    )
+    run_p.add_argument(
+        "--failsafe-mode",
+        action="store_true",
+        help="Continue running even if some tasks fail",
+    )
+    run_p.add_argument(
+        "--offline",
+        action="store_true",
+        help="Disable network access",
+    )
     run_p.add_argument(
         "--simulate",
         action="store_true",
         help="Show DAG and resources without executing",
     )
-    run_p.add_argument("--no-cache", action="store_true", help="Disable task caching")
+    run_p.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Disable task caching",
+    )
     run_p.add_argument(
         "--max-workers",
         type=int,
@@ -47,7 +80,7 @@ def cli() -> None:
         "--export-png",
         type=str,
         metavar="PATH",
-        help="Export a PNG visualization of the DAG to the given path.",
+        help="Export a PNG visualization of the DAG to PATH",
     )
     run_p.add_argument(
         "--export-stats",
@@ -61,7 +94,8 @@ def cli() -> None:
     rad_p.add_argument("--out-dir", default="rad_results")
     rad_p.add_argument("--simulate", action="store_true")
 
-    conv_p = sub.add_parser("convert", help="Convert Parsl/Dask <-> Parslet scripts")
+    conv_help = "Convert Parsl/Dask <-> Parslet scripts"
+    conv_p = sub.add_parser("convert", help=conv_help)
     conv_p.add_argument("--from-parsl", metavar="PATH")
     conv_p.add_argument("--to-parslet", metavar="PATH")
     conv_p.add_argument("--from-parslet", metavar="PATH")
@@ -78,179 +112,205 @@ def cli() -> None:
     load_plugins()
     logger.info("Plugins loaded")
 
-    if args.cmd == "run":
-        import threading
-        import time
-        from pathlib import Path
+    try:
+        if args.cmd == "run":
+            import threading
+            import time
+            from pathlib import Path
 
-        from rich.live import Live
-        from rich.table import Table
+            from rich.live import Live
+            from rich.table import Table
 
-        from parslet.cli import load_workflow_module
-        from parslet.core import DAG, DAGRunner
-        from parslet.core.policy import AdaptivePolicy
-        from parslet.security.defcon import Defcon
+            from parslet.cli import load_workflow_module
+            from parslet.core import DAG, DAGRunner
+            from parslet.core.policy import AdaptivePolicy
+            from parslet.security.defcon import Defcon
 
-        wf_input = args.workflow
-        mod = load_workflow_module(wf_input)
-        wf = Path(mod.__file__ or "")
-        if wf and not Defcon.scan_code([wf]):
-            logger.error("DEFCON1 rejection: unsafe code")
-            return
-        futures = mod.main()
-        dag = DAG()
-        dag.build_dag(futures)
+            wf_input = args.workflow
+            mod = load_workflow_module(wf_input)
+            wf = Path(mod.__file__ or "")
+            if wf and not Defcon.scan_code([wf]):
+                logger.error("DEFCON1 rejection: unsafe code")
+                return
+            futures = mod.main()
+            dag = DAG()
+            dag.build_dag(futures)
 
-        if args.export_png:
-            try:
-                dag.save_png(args.export_png)
-                logger.info(f"DAG visualization saved to {args.export_png}")
-            except Exception as e:
-                logger.error(f"Failed to export DAG to PNG: {e}", exc_info=False)
+            if getattr(mod, "__converted_from_parsl__", False):
+                from parslet.compat.parsl_adapter import export_parsl_dag
 
-        policy = None
-        if args.battery_mode:
-            policy = AdaptivePolicy(max_workers=2, battery_threshold=40)
-        runner = DAGRunner(
-            policy=policy,
-            failsafe_mode=args.failsafe_mode,
-            watch_files=[str(wf)] if wf else None,
-            disable_cache=args.no_cache,
-            json_logs=args.json_logs,
-            max_workers=args.max_workers,
-        )
+                orig = Path(getattr(mod, "__original_parsl_path__"))
+                export_name = f"{orig.stem}_parslet_export.py"
+                export_path = orig.with_name(export_name)
+                try:
+                    export_parsl_dag(futures, str(export_path))
+                    msg = "Parsl export written to " + f"{export_path}"
+                    logger.info(msg)
+                except Exception as e:
+                    logger.error(
+                        f"Could not export Parsl workflow: {e}", exc_info=False
+                    )
 
-        if args.simulate:
-            print("--- DAG Simulation ---")
-            print(dag.draw_dag())
-            from parslet.utils.resource_utils import (
-                get_available_ram_mb,
-                get_battery_level,
+            if args.export_png:
+                try:
+                    dag.save_png(args.export_png)
+                    msg = "DAG visualization saved to " + f"{args.export_png}"
+                    logger.info(msg)
+                except Exception as e:
+                    err = f"Failed to export DAG to PNG: {e}"
+                    logger.error(err, exc_info=False)
+
+            policy = None
+            if args.battery_mode:
+                policy = AdaptivePolicy(max_workers=2, battery_threshold=40)
+            runner = DAGRunner(
+                policy=policy,
+                failsafe_mode=args.failsafe_mode,
+                watch_files=[str(wf)] if wf else None,
+                disable_cache=args.no_cache,
+                json_logs=args.json_logs,
+                max_workers=args.max_workers,
             )
 
-            ram = get_available_ram_mb()
-            batt = get_battery_level()
-            if ram is not None:
-                print(f"Available RAM: {ram:.1f} MB")
-            if batt is not None:
-                print(f"Battery level: {batt}%")
-            return
+            if args.simulate:
+                print("--- DAG Simulation ---")
+                print(dag.draw_dag())
+                from parslet.utils import resource_utils
 
-        if args.monitor:
+                ram = resource_utils.get_available_ram_mb()
+                batt = resource_utils.get_battery_level()
+                if ram is not None:
+                    print(f"Available RAM: {ram:.1f} MB")
+                if batt is not None:
+                    print(f"Battery level: {batt}%")
+                return
 
-            def _run() -> None:
-                with offline_guard(args.offline):
-                    runner.run(dag)
+            if args.monitor:
 
-            t = threading.Thread(target=_run)
-            t.start()
-            with Live(refresh_per_second=4) as live:
-                while t.is_alive():
+                def _run() -> None:
+                    with offline_guard(args.offline):
+                        runner.run(dag)
+
+                t = threading.Thread(target=_run)
+                t.start()
+                with Live(refresh_per_second=4) as live:
+                    while t.is_alive():
+                        table = Table()
+                        table.add_column("Task")
+                        table.add_column("Status")
+                        for tid, status in runner.task_statuses.items():
+                            table.add_row(tid, status)
+                        live.update(table)
+                        time.sleep(0.5)
+                    t.join()
                     table = Table()
                     table.add_column("Task")
                     table.add_column("Status")
                     for tid, status in runner.task_statuses.items():
                         table.add_row(tid, status)
                     live.update(table)
-                    time.sleep(0.5)
-                t.join()
-                table = Table()
-                table.add_column("Task")
-                table.add_column("Status")
-                for tid, status in runner.task_statuses.items():
-                    table.add_row(tid, status)
-                live.update(table)
-        else:
-            with offline_guard(args.offline):
-                runner.run(dag)
-            if args.export_stats:
-                try:
-                    with open(args.export_stats, "w", encoding="utf-8") as fh:
-                        json.dump(
-                            {
-                                "task_statuses": runner.task_statuses,
-                                "task_execution_times": runner.task_execution_times,
-                            },
-                            fh,
-                            indent=2,
-                        )
-                    logger.info(f"Execution stats exported to {args.export_stats}")
-                except Exception as e:  # pragma: no cover - defensive
-                    logger.error(f"Failed to export stats: {e}", exc_info=False)
-    elif args.cmd == "rad":
-        from examples.rad_parslet.rad_dag import main as rad_main
-        from parslet.core import DAG, DAGRunner
+            else:
+                with offline_guard(args.offline):
+                    runner.run(dag)
+                if args.export_stats:
+                    try:
+                        stats_path = args.export_stats
+                        with open(stats_path, "w", encoding="utf-8") as fh:
+                            json.dump(
+                                {
+                                    "task_statuses": runner.task_statuses,
+                                    "task_execution_times": (
+                                        runner.task_execution_times
+                                    ),
+                                },
+                                fh,
+                                indent=2,
+                            )
+                        msg = "Stats written to " + f"{args.export_stats}"
+                        logger.info(msg)
+                    except Exception as e:  # pragma: no cover - defensive
+                        err = f"Failed to export stats: {e}"
+                        logger.error(err, exc_info=False)
+        elif args.cmd == "rad":
+            from examples.rad_parslet.rad_dag import main as rad_main
+            from parslet.core import DAG, DAGRunner
 
-        futures = rad_main(args.image, args.out_dir)
-        dag = DAG()
-        dag.build_dag(futures)
+            futures = rad_main(args.image, args.out_dir)
+            dag = DAG()
+            dag.build_dag(futures)
 
-        if args.simulate:
-            print("--- RAD DAG Simulation ---")
-            print(dag.draw_dag())
-            return
+            if args.simulate:
+                print("--- RAD DAG Simulation ---")
+                print(dag.draw_dag())
+                return
 
-        runner = DAGRunner()
-        runner.run(dag)
+            runner = DAGRunner()
+            runner.run(dag)
 
-    elif args.cmd == "convert":
-        from parslet.cli import load_workflow_module
-        from parslet.compat.dask_adapter import (
-            export_dask_dag,
-            import_dask_script,
-        )
-        from parslet.compat.parsl_adapter import (
-            export_parsl_dag,
-            import_parsl_script,
-        )
+        elif args.cmd == "convert":
+            from parslet.cli import load_workflow_module
+            from parslet.compat import dask_adapter, parsl_adapter
 
-        if args.from_parsl and args.to_parslet:
-            import_parsl_script(args.from_parsl, args.to_parslet)
-            print(
-                "Warning: experimental conversion; no staging, pure-Python bodies only",
-                flush=True,
-            )
-        elif args.from_parslet and args.to_parsl:
-            mod = load_workflow_module(args.from_parslet)
-            futures = mod.main()
-            export_parsl_dag(futures, args.to_parsl)
-            print(
-                "Warning: experimental conversion; no staging, pure-Python bodies only",
-                flush=True,
-            )
-        elif args.from_dask and args.to_parslet:
-            import_dask_script(args.from_dask, args.to_parslet)
-            print(
-                "Warning: experimental conversion; no staging, pure-Python bodies only",
-                flush=True,
-            )
-        elif args.from_parslet and args.to_dask:
-            mod = load_workflow_module(args.from_parslet)
-            futures = mod.main()
-            export_dask_dag(futures, args.to_dask)
-            print(
-                "Warning: experimental conversion; no staging, pure-Python bodies only",
-                flush=True,
-            )
-        else:
-            print(
-                "Specify --from-parsl/--to-parslet, --from-parslet/--to-parsl,"
-                " --from-dask/--to-parslet or --from-parslet/--to-dask",
-                flush=True,
-            )
-    elif args.cmd == "test":
-        import pytest
+            if args.from_parsl and args.to_parslet:
+                parsl_adapter.import_parsl_script(
+                    args.from_parsl,
+                    args.to_parslet,
+                )
+                print(
+                    "Warning: experimental conversion; no staging, "
+                    "pure-Python bodies only",
+                    flush=True,
+                )
+            elif args.from_parslet and args.to_parsl:
+                mod = load_workflow_module(args.from_parslet)
+                futures = mod.main()
+                parsl_adapter.export_parsl_dag(futures, args.to_parsl)
+                print(
+                    "Warning: experimental conversion; no staging, "
+                    "pure-Python bodies only",
+                    flush=True,
+                )
+            elif args.from_dask and args.to_parslet:
+                dask_adapter.import_dask_script(
+                    args.from_dask,
+                    args.to_parslet,
+                )
+                print(
+                    "Warning: experimental conversion; no staging, "
+                    "pure-Python bodies only",
+                    flush=True,
+                )
+            elif args.from_parslet and args.to_dask:
+                mod = load_workflow_module(args.from_parslet)
+                futures = mod.main()
+                dask_adapter.export_dask_dag(futures, args.to_dask)
+                print(
+                    "Warning: experimental conversion; no staging, "
+                    "pure-Python bodies only",
+                    flush=True,
+                )
+            else:
+                print(
+                    "Specify --from-parsl/--to-parslet, "
+                    "--from-parslet/--to-parsl, --from-dask/--to-parslet "
+                    "or --from-parslet/--to-dask",
+                    flush=True,
+                )
+        elif args.cmd == "test":
+            import pytest
 
-        pytest.main(["-q", "tests"])
-    elif args.cmd == "diagnose":
-        from .utils.diagnostics import find_free_port
+            pytest.main(["-q", "tests"])
+        elif args.cmd == "diagnose":
+            from .utils.diagnostics import find_free_port
 
-        print("Free port:", find_free_port())
-    elif args.cmd == "examples":
-        from pathlib import Path
+            print("Free port:", find_free_port())
+        elif args.cmd == "examples":
+            from pathlib import Path
 
-        for f in Path("use_cases").glob("*.py"):
-            print(f.name)
+            for f in Path("use_cases").glob("*.py"):
+                print(f.name)
+    except Exception as exc:  # pragma: no cover - friendly error surface
+        logger.error(f"An error occurred: {exc}", exc_info=False)
 
 
 def main() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 from importlib import import_module
 from pathlib import Path
+
 import pytest
 
 
@@ -9,7 +10,7 @@ def test_cli_help(capsys, monkeypatch):
     monkeypatch.setattr(module.sys, "argv", ["parslet"])
     module.cli()
     out = capsys.readouterr().out
-    assert "Parslet command line" in out
+    assert "Parslet command line" in out or "Parslet CLI" in out
 
 
 def test_cli_examples_listing(capsys):
@@ -29,7 +30,7 @@ def test_cli_help_option(capsys):
     with pytest.raises(SystemExit):
         module.main()
     out = capsys.readouterr().out
-    assert "Parslet command line" in out
+    assert "Parslet command line" in out or "Parslet CLI" in out
 
 
 def test_cli_invalid_argument(capsys):
@@ -49,11 +50,8 @@ def test_cli_examples_all_files(capsys):
     except SystemExit:
         pass
     out = capsys.readouterr().out
-    lines = [
-        line
-        for line in out.strip().splitlines()
-        if "Plugins loaded" not in line
-    ]
+    out_lines = out.strip().splitlines()
+    lines = [line for line in out_lines if "Plugins loaded" not in line]
     listed = sorted(lines)
     expected = sorted(f.name for f in Path("use_cases").glob("*.py"))
     assert listed == expected

--- a/tests/test_parsl_auto.py
+++ b/tests/test_parsl_auto.py
@@ -1,0 +1,36 @@
+from importlib import import_module
+from pathlib import Path
+
+from parslet import ParsletFuture
+from parslet.cli import load_workflow_module
+
+
+def test_load_module_auto_converts(tmp_path: Path) -> None:
+    wf = tmp_path / "wf_parsl.py"
+    wf.write_text(
+        "from parsl import python_app\n"
+        "@python_app\n"
+        "def a():\n    return 1\n"
+        "x = a()\n"
+    )
+    mod = load_workflow_module(str(wf))
+    assert getattr(mod, "__converted_from_parsl__", False)
+    futures = mod.main()
+    assert all(isinstance(f, ParsletFuture) for f in futures)
+
+
+def test_cli_run_exports_parsl(tmp_path: Path, monkeypatch) -> None:
+    wf = tmp_path / "wf_parsl.py"
+    wf.write_text(
+        "from parsl import python_app\n"
+        "@python_app\n"
+        "def a():\n    return 1\n"
+        "x = a()\n"
+    )
+    module = import_module("parslet.main_cli")
+    monkeypatch.setattr(module, "sys", module.sys)
+    module.sys.argv = ["parslet", "run", str(wf)]
+    module.main()
+    exported = tmp_path / "wf_parsl_parslet_export.py"
+    assert exported.exists()
+    assert "@python_app" in exported.read_text()


### PR DESCRIPTION
## Summary
- expand CLI help text and options for easier workflow execution
- auto-convert Parsl workflows and export Parsl-friendly scripts
- add tests for Parsl auto-recognition

## Testing
- `pre-commit run --files parslet/cli.py parslet/main_cli.py tests/test_parsl_auto.py tests/test_cli.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afd0b9ac8883339045e0b6d8463628