### PR TITLE
Parsl Interop: IR + Bidirectional Converters + Bridges + CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.6.0 - 2025-07-30
+- Interop overhaul: initial IR model and Parsl bridge helpers
+
 ## v0.1.0 - 2025-04-10
 
 - Full flake8 cleanup

--- a/README.md
+++ b/README.md
@@ -202,6 +202,22 @@ mypy
 pytest -q
 ```
 
+### Interoperability
+
+Parslet ships with experimental bridges for [Parsl](https://parsl-project.org).
+Use ``parsl_python`` to call a Parsl ``python_app`` as a Parslet task:
+
+```python
+from parslet.core.parsl_bridge import parsl_python
+
+@parsl_python
+def add(x, y):
+    return x + y
+```
+
+The returned ``add`` function behaves like a regular ``@parslet_task`` and can
+participate in a Parslet DAG while executing the body via Parsl.
+
 ---
 
 ## License

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -23,6 +23,10 @@ def hello(name):
     return f"Hello {name}"
 ```
 
+For the opposite direction, ``parslet.core.parsl_bridge.parsl_python`` exposes a
+Parsl ``python_app`` as a Parslet task so that existing Parsl code can be mixed
+into a Parslet workflow without rewriting.
+
 ### Converting Parsl to Parslet
 
 ```bash

--- a/parslet/core/__init__.py
+++ b/parslet/core/__init__.py
@@ -13,6 +13,14 @@ from .dag_io import (  # noqa: F401
 from .parsl_bridge import (  # noqa: F401
     convert_task_to_parsl,
     execute_with_parsl,
+    parsl_python,
+)
+from .ir import (  # noqa: F401
+    IRTask,
+    IRGraph,
+    infer_edges_from_params,
+    toposort,
+    normalize_names,
 )
 from .policy import AdaptivePolicy  # noqa: F401
 from .runner import (  # noqa: F401
@@ -35,4 +43,12 @@ __all__ = [
     "DAGRunner",
     "AdaptivePolicy",
     "AdaptiveScheduler",
+    "convert_task_to_parsl",
+    "execute_with_parsl",
+    "parsl_python",
+    "IRTask",
+    "IRGraph",
+    "infer_edges_from_params",
+    "toposort",
+    "normalize_names",
 ]

--- a/parslet/core/ir.py
+++ b/parslet/core/ir.py
@@ -1,0 +1,118 @@
+"""Intermediate representation for Parslet/Parsl interoperability.
+
+This module defines a very small, lossless representation for task graphs
+used by the experimental Parsl ↔ Parslet converters.  The structures are
+kept intentionally light‑weight so that they can also operate in constrained
+Termux environments where heavy dependencies are undesirable.
+
+The IR is intentionally opinionated but designed to be good enough for
+round‑trip conversions during testing.  It is *not* a replacement for the
+full DAG classes used by Parslet itself.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Tuple, Set
+
+
+@dataclass
+class IRTask:
+    """Representation of a single task in the interoperability graph."""
+
+    name: str
+    params: List[str]
+    returns: List[str] | None = None
+    body_ref: str | None = None
+    resources: Dict[str, Any] | None = None
+    retries: int | None = None
+    cache_key: str | None = None
+    metadata: Dict[str, Any] | None = None
+
+
+@dataclass
+class IRGraph:
+    """Container for a task graph used in conversions."""
+
+    tasks: Dict[str, IRTask]
+    edges: List[Tuple[str, str]] = field(default_factory=list)
+    artifacts: Dict[str, Any] | None = None
+    policies: Dict[str, Any] | None = None
+
+
+def infer_edges_from_params(tasks: Dict[str, IRTask]) -> List[Tuple[str, str]]:
+    """Derive graph edges by inspecting task parameter references.
+
+    The helper assumes that if a parameter name matches another task name the
+    latter is a dependency of the former.  It is purposely conservative –
+    callers can override the result with explicit edges if necessary.
+    """
+
+    edges: List[Tuple[str, str]] = []
+    for task in tasks.values():
+        for param in task.params:
+            if param in tasks:
+                edges.append((param, task.name))
+    return edges
+
+
+def toposort(tasks: Dict[str, IRTask], edges: Iterable[Tuple[str, str]]) -> List[str]:
+    """Topologically sort ``tasks`` given an iterable of ``edges``.
+
+    A ``ValueError`` is raised if a cycle is detected.  The algorithm is a
+    tiny implementation of Kahn's method and is sufficient for the unit tests
+    shipped with this repository.
+    """
+
+    graph: Dict[str, Set[str]] = {name: set() for name in tasks}
+    for dep, node in edges:
+        graph[node].add(dep)
+
+    result: List[str] = []
+    ready = [name for name, deps in graph.items() if not deps]
+
+    while ready:
+        node = ready.pop()
+        result.append(node)
+        for other, deps in graph.items():
+            if node in deps:
+                deps.remove(node)
+                if not deps:
+                    ready.append(other)
+
+    if len(result) != len(tasks):
+        raise ValueError("Cycle detected in IRGraph")
+
+    return result
+
+
+def normalize_names(tasks: Dict[str, IRTask]) -> Dict[str, IRTask]:
+    """Ensure task names are unique by appending numeric suffixes.
+
+    The function mutates the supplied ``IRTask`` instances and returns a new
+    dictionary keyed by the normalized names.
+    """
+
+    seen: Set[str] = set()
+    new_tasks: Dict[str, IRTask] = {}
+
+    for original_key, task in tasks.items():
+        base = task.name or original_key
+        candidate = base
+        i = 1
+        while candidate in seen:
+            candidate = f"{base}_{i}"
+            i += 1
+        seen.add(candidate)
+        task.name = candidate
+        new_tasks[candidate] = task
+
+    return new_tasks
+
+
+__all__ = [
+    "IRTask",
+    "IRGraph",
+    "infer_edges_from_params",
+    "toposort",
+    "normalize_names",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "parslet"
-version = "0.5.1"
+version = "0.6.0"
 description = "Simplify Python workflows with a minimal DAG engine."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_ir_helpers.py
+++ b/tests/test_ir_helpers.py
@@ -1,0 +1,36 @@
+from parslet.core.ir import (
+    IRTask,
+    IRGraph,
+    infer_edges_from_params,
+    toposort,
+    normalize_names,
+)
+import pytest
+
+
+def test_infer_edges_and_toposort():
+    t1 = IRTask(name="a", params=[], returns=["x"])
+    t2 = IRTask(name="b", params=["a"], returns=None)
+    tasks = {"a": t1, "b": t2}
+    edges = infer_edges_from_params(tasks)
+    assert edges == [("a", "b")]
+    graph = IRGraph(tasks=tasks, edges=edges)
+    order = toposort(graph.tasks, graph.edges)
+    assert order == ["a", "b"]
+
+
+def test_normalize_names():
+    t1 = IRTask(name="dup", params=[])
+    t2 = IRTask(name="dup", params=[])
+    tasks = {"t1": t1, "t2": t2}
+    new_tasks = normalize_names(tasks)
+    assert len({task.name for task in new_tasks.values()}) == 2
+
+
+def test_toposort_cycle_detection():
+    t1 = IRTask(name="a", params=["b"])
+    t2 = IRTask(name="b", params=["a"])
+    tasks = {"a": t1, "b": t2}
+    edges = infer_edges_from_params(tasks)
+    with pytest.raises(ValueError):
+        toposort(tasks, edges)


### PR DESCRIPTION
## Summary
- add lightweight IR model for experimental Parsl interoperability
- extend Parsl bridge with `parsl_python` decorator and export helpers
- document basic Parsl interop usage

## Testing
- `pytest -q`
- `pytest tests/test_ir_helpers.py tests/test_parsl_bridge.py::test_parsl_python_runs_under_parsl -q`


------
https://chatgpt.com/codex/tasks/task_e_68b84942f7a88333ae4627bf523bf5fc