### PR TITLE
Battery Intelligence: cross-platform power telemetry + energy-aware EDF + dynamic concurrency + variants + CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Most tools like this are built for powerful servers in a data center. Parslet is
 -   **Run in Termux:** It’s built and tested to work perfectly inside [Termux](https://termux.dev/en/), the command-line tool for Android.
 -   **Work Offline:** No internet? No problem. Your workflows will still run.
 -   **Empower Everyone:** It’s for students, creators, and developers who might not have a laptop but have a brilliant idea.
+-   **Battery-smart scheduling:** Adapts on Android, Raspberry Pi, and Linux laptops to stretch runtime.
 
 ---
 

--- a/parslet/__init__.py
+++ b/parslet/__init__.py
@@ -5,7 +5,15 @@ interface compact and easy to learn.  Everything else remains available under
 ``parslet.core`` or other subpackages.
 """
 
-from .core import DAG, DAGRunner, ParsletFuture, parslet_task
+from .core import (
+    DAG,
+    DAGRunner,
+    EnergyAwarePolicy,
+    ParsletFuture,
+    parslet_task,
+    task_variant,
+)
+from .utils.power import PowerState, get_power_state, watch
 
 try:
     from importlib.metadata import version as _pkg_version
@@ -17,4 +25,14 @@ try:
 except Exception:
     __version__ = "0.0.0"
 
-__all__ = ["parslet_task", "ParsletFuture", "DAG", "DAGRunner"]
+__all__ = [
+    "parslet_task",
+    "ParsletFuture",
+    "DAG",
+    "DAGRunner",
+    "task_variant",
+    "EnergyAwarePolicy",
+    "PowerState",
+    "get_power_state",
+    "watch",
+]

--- a/parslet/core/__init__.py
+++ b/parslet/core/__init__.py
@@ -10,26 +10,31 @@ from .dag_io import (  # noqa: F401
     export_dag_to_json,
     import_dag_from_json,
 )
+from .ir import (  # noqa: F401
+    IRGraph,
+    IRTask,
+    infer_edges_from_params,
+    normalize_names,
+    toposort,
+)
 from .parsl_bridge import (  # noqa: F401
     convert_task_to_parsl,
     execute_with_parsl,
     parsl_python,
 )
-from .ir import (  # noqa: F401
-    IRTask,
-    IRGraph,
-    infer_edges_from_params,
-    toposort,
-    normalize_names,
-)
-from .policy import AdaptivePolicy  # noqa: F401
+from .policy import AdaptivePolicy, EnergyAwarePolicy  # noqa: F401
 from .runner import (  # noqa: F401
     BatteryLevelLowError,
     DAGRunner,
     UpstreamTaskFailedError,
 )
 from .scheduler import AdaptiveScheduler  # noqa: F401
-from .task import ParsletFuture, parslet_task, set_allow_redefine  # noqa: F401
+from .task import (  # noqa: F401
+    ParsletFuture,
+    parslet_task,
+    set_allow_redefine,
+    task_variant,
+)
 
 try:
     __version__ = metadata.version("parslet")
@@ -42,6 +47,7 @@ __all__ = [
     "DAG",
     "DAGRunner",
     "AdaptivePolicy",
+    "EnergyAwarePolicy",
     "AdaptiveScheduler",
     "convert_task_to_parsl",
     "execute_with_parsl",

--- a/parslet/utils/power.py
+++ b/parslet/utils/power.py
@@ -1,0 +1,147 @@
+"""Cross-platform power telemetry helpers.
+
+This module exposes a small dataclass :class:`PowerState` and a
+``get_power_state`` function that attempts to gather battery and thermal
+information from the running system.  The implementation intentionally keeps
+its dependencies light so it can operate in constrained environments such as
+Android/Termux or Raspberry Pi.  When no information is available the function
+falls back to conservative defaults instead of raising errors.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+try:  # psutil is part of the base requirements
+    import psutil
+except Exception:  # pragma: no cover - psutil always available in tests
+    psutil = None  # type: ignore
+
+
+@dataclass
+class PowerState:
+    """Snapshot of the system's current power conditions."""
+
+    source: Literal["battery", "ac", "unknown"] = "unknown"
+    percent: int | None = None
+    is_charging: bool | None = None
+    est_time_to_empty_min: int | None = None
+    est_time_to_full_min: int | None = None
+    temperature_c: float | None = None
+    cpu_freq_hint: int | None = None  # kHz
+    thermal_throttle: bool = False
+    ts: float = 0.0
+
+
+def _psutil_provider() -> PowerState | None:
+    """Return power information using :mod:`psutil` if available."""
+
+    if psutil is None:
+        return None
+    try:
+        batt = psutil.sensors_battery()
+    except Exception:
+        return None
+    if batt is None:
+        return None
+
+    secs = batt.secsleft
+    mins = None
+    if secs not in (psutil.POWER_TIME_UNLIMITED, psutil.POWER_TIME_UNKNOWN):
+        mins = int(secs // 60)
+
+    return PowerState(
+        source="ac" if batt.power_plugged else "battery",
+        percent=int(batt.percent) if batt.percent is not None else None,
+        is_charging=batt.power_plugged,
+        est_time_to_empty_min=mins if not batt.power_plugged else None,
+        est_time_to_full_min=mins if batt.power_plugged else None,
+        ts=time.time(),
+    )
+
+
+def _sysfs_provider() -> PowerState | None:
+    """Attempt to gather battery info from ``/sys`` paths."""
+
+    base = Path("/sys/class/power_supply")
+    if not base.exists():
+        return None
+    bat_paths = list(base.glob("BAT*"))
+    if not bat_paths:
+        return None
+    try:
+        status = (bat_paths[0] / "status").read_text().strip().lower()
+        percent = int((bat_paths[0] / "capacity").read_text().strip())
+    except Exception:
+        return None
+    return PowerState(
+        source="battery",
+        percent=percent,
+        is_charging=status == "charging",
+        ts=time.time(),
+    )
+
+
+def _termux_provider() -> PowerState | None:
+    """Use ``termux-battery-status`` if available on the PATH."""
+
+    try:
+        out = subprocess.check_output(["termux-battery-status"], text=True, timeout=2)
+    except Exception:
+        return None
+    try:
+        import json
+
+        data = json.loads(out)
+    except Exception:
+        return None
+    return PowerState(
+        source="battery" if data.get("status") != "AC" else "ac",
+        percent=data.get("percentage"),
+        is_charging=data.get("status") == "CHARGING",
+        temperature_c=data.get("temperature"),
+        ts=time.time(),
+    )
+
+
+_PROVIDERS = [_termux_provider, _psutil_provider, _sysfs_provider]
+
+
+def get_power_state() -> PowerState:
+    """Return the best effort :class:`PowerState` for the system.
+
+    Providers are tried in order and the first non-``None`` result is used.
+    If every provider fails, a ``PowerState`` with ``source='unknown'`` is
+    returned.  All provider errors are swallowed so callers can use this
+    function without defensive ``try`` blocks.
+    """
+
+    for provider in _PROVIDERS:
+        state = provider()
+        if state is not None:
+            return state
+    # fall back to conservative defaults
+    return PowerState(ts=time.time())
+
+
+def watch(
+    interval_s: int = 20, on_change: Callable[[PowerState], None] | None = None
+) -> Iterator[PowerState]:
+    """Yield :class:`PowerState` snapshots at a fixed interval.
+
+    The generator yields the latest :class:`PowerState` and optionally calls
+    ``on_change`` with the new value.  This is a simple building block used by
+    higher level scheduling components.
+    """
+
+    while True:
+        state = get_power_state()
+        if on_change is not None:
+            on_change(state)
+        yield state
+        time.sleep(interval_s)

--- a/tests/test_api_surface.py
+++ b/tests/test_api_surface.py
@@ -2,5 +2,15 @@ import parslet
 
 
 def test_top_level_public_api() -> None:
-    expected = {"parslet_task", "ParsletFuture", "DAG", "DAGRunner"}
+    expected = {
+        "parslet_task",
+        "ParsletFuture",
+        "DAG",
+        "DAGRunner",
+        "task_variant",
+        "EnergyAwarePolicy",
+        "PowerState",
+        "get_power_state",
+        "watch",
+    }
     assert set(parslet.__all__) == expected

--- a/tests/test_energy_policy_ordering.py
+++ b/tests/test_energy_policy_ordering.py
@@ -1,0 +1,21 @@
+from parslet.core.policy import EnergyAwarePolicy
+from parslet.core.task import parslet_task
+from parslet.utils.power import PowerState
+
+
+@parslet_task(energy_cost="high", deadline_s=10, qos="standard")
+def expensive() -> str:
+    return "expensive"
+
+
+@parslet_task(energy_cost="low", deadline_s=10, qos="standard")
+def cheap() -> str:
+    return "cheap"
+
+
+def test_low_battery_prefers_low_energy() -> None:
+    futures = [expensive(), cheap()]
+    policy = EnergyAwarePolicy(low_battery_threshold=40)
+    power = PowerState(source="battery", percent=20)
+    ordered = policy.order(futures, power)
+    assert ordered[0].func.__name__ == "cheap"

--- a/tests/test_power_providers.py
+++ b/tests/test_power_providers.py
@@ -1,0 +1,10 @@
+from parslet.utils.power import PowerState, get_power_state
+
+
+def test_get_power_state_returns_snapshot() -> None:
+    state = get_power_state()
+    assert isinstance(state, PowerState)
+    assert state.source in {"battery", "ac", "unknown"}
+    # percent may be None but if provided it should be within 0-100
+    if state.percent is not None:
+        assert 0 <= state.percent <= 100

--- a/tests/test_variants_selection.py
+++ b/tests/test_variants_selection.py
@@ -1,0 +1,18 @@
+from parslet.core.task import parslet_task, task_variant
+
+
+@parslet_task
+def process_full() -> str:
+    return "full"
+
+
+@task_variant("light")
+@parslet_task
+def process_light() -> str:
+    return "light"
+
+
+def test_variant_annotation_present() -> None:
+    assert process_light._parslet_variant_key == "light"
+    fut = process_light()
+    assert fut.variant_key == "light"


### PR DESCRIPTION
## Summary
- add cross-platform power telemetry helpers and PowerState dataclass
- extend parslet_task with energy metadata and variant decorator
- introduce EnergyAwarePolicy for battery-aware task ordering
- expose new APIs and document battery-smart scheduling

## Testing
- `ruff check parslet/utils/power.py parslet/core/task.py parslet/core/policy.py parslet/__init__.py parslet/core/__init__.py tests/test_power_providers.py tests/test_energy_policy_ordering.py tests/test_variants_selection.py tests/test_api_surface.py`
- `black parslet/utils/power.py parslet/core/task.py parslet/core/policy.py parslet/__init__.py parslet/core/__init__.py tests/test_power_providers.py tests/test_energy_policy_ordering.py tests/test_variants_selection.py tests/test_api_surface.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b84f60fe308333af2a5e535d72f08d