### PR TITLE
Handle invalid arguments in network reachability check

### DIFF
--- a/parslet/utils/network_utils.py
+++ b/parslet/utils/network_utils.py
@@ -19,7 +19,13 @@ def is_network_available(
     try:
         with socket.create_connection((host, port), timeout=timeout):
             return True
-    except OSError:
+    except Exception:
+        # ``socket.create_connection`` can raise a variety of exceptions
+        # depending on the type and value of ``timeout`` or the reachability of
+        # the host.  In addition to ``OSError`` (for network errors) it may
+        # raise ``ValueError`` or ``TypeError`` when invalid parameters are
+        # supplied.  Treat all of these cases as "network unavailable" instead
+        # of propagating the error so callers get a simple True/False result.
         return False
 
 


### PR DESCRIPTION
## Summary
- make `is_network_available` robust to invalid parameters and non-network exceptions

## Testing
- `pytest tests/test_network_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b891be74448333be8f766f7bd207ee