### PR TITLE
Add concierge context orchestration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.6.1 - 2025-10-07
+- Added ContextOracle scenes and `contexts` task metadata with CLI integration.
+- Introduced Concierge orchestrator with pre-flight briefings and JSON runbooks.
+- Expanded documentation and tests around luxury workflows and contextual gating.
+
 ## v0.6.0 - 2025-07-30
 - Interop overhaul: initial IR model and Parsl bridge helpers
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Parslet is small, but it's packed with neat features for real-world use.
 -   **DEFCON:** A multi-layered defense system in Parslet that proactively blocks zero-day exploits and malicious DAG behavior using offline rules. Learn more in the [security notes](docs/technical-overview.md).
 -   **Plays Well with Others:** If you ever move to a big server, Parslet has tools to convert your recipes to run on powerful systems like Parsl or Dask. See [compatibility](docs/compatibility.md).
 -   **Made for Termux:** We use it and test it on Android phones, so you know it'll work. Check the [install guide](docs/install.md).
+-   **Concierge Mode & Context Scenes:** `parslet run --concierge` gives you a luxury pre-flight briefing, live context audit, and a polished post-run ledger. Combine it with `@parslet_task(contexts=[...])` to ensure tasks only run when the right battery, network, or time-of-day scene is active.
 
 Want to see more? Check out the `use_cases/` and `examples/` folders for more advanced recipes!
 
@@ -158,6 +159,28 @@ Want to see more? Check out the `use_cases/` and `examples/` folders for more ad
 Parslet can generate a picture of your workflow (a "DAG") to help you see how your tasks are connected. This is great for debugging and documentation.
 
 To use this feature, you need to have **Graphviz** installed on your system.
+
+---
+
+## Concierge Mode & Context Scenes
+
+Parslet 0.6.1 introduces **Concierge Mode**, a premium orchestration experience that makes your workflow feel like it shipped with its own operations team.
+
+-   **Concierge Briefing:** Run `parslet run my_flow.py --concierge` to get a handcrafted pre-flight report. It shows which context detectors are live (battery, network, VPN, time-of-day) and which tasks are gated by those contexts.
+-   **Context Scenes:** Declare contextual requirements directly on tasks:
+
+    ```python
+    @parslet_task(contexts=["network.online", "battery>=60"], name="sync_to_vault")
+    def sync_to_vault(payload: dict) -> None:
+        upload(payload)
+    ```
+
+    Parslet will defer the task with a `DEFERRED` status if the context isn't satisfied, protecting your workflow just like the best Tasker rule sets—only with readable Python and offline detectors.
+
+-   **Manual Overrides:** Activate ad-hoc scenes with `parslet run my_flow.py --context evening --context wifi`. You can also set a `PARSLET_CONTEXTS="evening,wifi"` environment variable or programmatically enable custom detectors using `ContextOracle`.
+-   **Concierge Runbook:** Need a paper trail? Add `--concierge-runbook runbook.json` and Parslet will record the complete itinerary, task metadata, and execution timings in a JSON dossier.
+
+This combination gives Parslet the runway to outclass traditional mobile automation apps—every run feels bespoke, intentional, and enterprise ready.
 
 -   **On Linux (Debian/Ubuntu):** `sudo apt install graphviz`
 -   **On Linux (Fedora):** `sudo dnf install graphviz`

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -34,6 +34,15 @@ Here are some of the most common buttons you can press:
 ``--simulate``
     This is the "preview" button. It will show you the flowchart for your recipe and check your device's RAM and battery, but it won't actually run any of the tasks. It's great for double-checking your work.
 
+``--context <Name>``
+    Declare a luxury "scene" that should be considered active for this run. You can specify this flag multiple times. It partners with the new ``@parslet_task(contexts=[...])`` decorator to gate tasks until the right conditions (like ``network.online`` or ``battery>=60``) are met.
+
+``--concierge``
+    Treat yourself to Parslet's concierge briefing and ledger. You'll see a curated pre-flight summary of live detectors and a post-run ledger that reads like a boutique operations report.
+
+``--concierge-runbook <Path>``
+    Ask Parslet to write a JSON dossier with the complete itinerary, including context evaluations and execution timings. Perfect for sharing with clients or teammates.
+
 ``--export-dot`` / ``--export-png``
     These buttons tell Parslet to take a picture of your recipe's flowchart for you. See :doc:`exporting` for more details.
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -73,3 +73,20 @@ To analyze performance, export execution stats and plot an ASCII heatmap:
    python examples/tools/plot_stats.py stats.json
 
 For more command-line options, like exporting a picture of your workflow, check out the :doc:`cli` guide. To learn more about how battery mode works, see :doc:`battery_mode`.
+
+Curate Context Scenes
+---------------------
+
+Parslet tasks can now declare *context scenes* that must be active before they run. It's the same power you'd expect from Tasker, but native to your Python code.
+
+.. code-block:: python
+
+   from parslet import parslet_task
+
+   @parslet_task(contexts=["network.online", "battery>=60"], name="luxury_sync")
+   def luxury_sync(data: dict) -> None:
+       upload_to_vault(data)
+
+Use ``parslet run workflow.py --context home --context vpn`` to manually activate scenes, or rely on Parslet's detectors for network, VPN, power source, and time-of-day. Any task whose context is not satisfied is marked ``DEFERRED`` and safely skipped until conditions improve.
+
+Activate ``--concierge`` for a pre-flight briefing and ``--concierge-runbook`` for a JSON dossier containing the itinerary, context evaluations, and runtimes.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -33,3 +33,15 @@ And turn exported stats into an ASCII heatmap:
 ```bash
 python examples/tools/plot_stats.py stats.json
 ```
+
+## Concierge Mode and Context Scenes
+
+Parslet 0.6.1 ships with a concierge experience and declarative context scenes. Gate tasks with the new ``contexts`` parameter:
+
+```python
+@parslet_task(contexts=["network.online", "battery>=50"], name="evening_sync")
+def evening_sync(payload):
+    push_to_vault(payload)
+```
+
+Run with ``--concierge`` to receive a pre-flight briefing and post-run ledger, or ``--concierge-runbook runbook.json`` to capture the full itinerary in JSON. Manually activate scenes with repeated ``--context`` flags or via the ``PARSLET_CONTEXTS`` environment variable.

--- a/parslet/__init__.py
+++ b/parslet/__init__.py
@@ -6,6 +6,8 @@ interface compact and easy to learn.  Everything else remains available under
 """
 
 from .core import (
+    ConciergeOrchestrator,
+    ContextOracle,
     DAG,
     DAGRunner,
     EnergyAwarePolicy,
@@ -35,4 +37,6 @@ __all__ = [
     "PowerState",
     "get_power_state",
     "watch",
+    "ContextOracle",
+    "ConciergeOrchestrator",
 ]

--- a/parslet/core/__init__.py
+++ b/parslet/core/__init__.py
@@ -5,10 +5,11 @@ This module defines the long-term stable API surface of ``parslet.core``.
 
 from importlib import metadata
 
+from .concierge import ConciergeOrchestrator, ConciergeSummary  # noqa: F401
+from .context import ContextOracle, ContextResult  # noqa: F401
 from .dag import DAG, DAGCycleError  # noqa: F401
 from .dag_io import export_dag_to_json, import_dag_from_json  # noqa: F401
-from .ir import infer_edges_from_params  # noqa: F401
-from .ir import IRGraph, IRTask, normalize_names, toposort
+from .ir import IRGraph, IRTask, infer_edges_from_params, normalize_names, toposort
 from .parsl_bridge import convert_task_to_parsl  # noqa: F401
 from .parsl_bridge import execute_with_parsl, parsl_python
 from .policy import AdaptivePolicy, EnergyAwarePolicy  # noqa: F401
@@ -33,6 +34,10 @@ __all__ = [
     "AdaptivePolicy",
     "EnergyAwarePolicy",
     "AdaptiveScheduler",
+    "ContextOracle",
+    "ContextResult",
+    "ConciergeOrchestrator",
+    "ConciergeSummary",
     "set_allow_redefine",
     "task_variant",
     "convert_task_to_parsl",

--- a/parslet/core/concierge.py
+++ b/parslet/core/concierge.py
@@ -1,0 +1,189 @@
+"""Concierge orchestration utilities.
+
+The Concierge surface gives Parslet a luxury-handcrafted feel. It produces
+polished previews, curates contextual requirements and writes a runbook that
+captures the story of a workflow execution.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Iterable
+
+from .context import ContextOracle, ContextResult
+from .dag import DAG
+
+
+@dataclass(slots=True)
+class ConciergeSummary:
+    """Bundle of useful counters about a DAG run."""
+
+    total_tasks: int
+    completed: int
+    deferred: int
+    failed: int
+    skipped: int
+    total_runtime: float
+    slowest_task: str | None = None
+    slowest_duration: float | None = None
+
+
+class ConciergeOrchestrator:
+    """Generate high-touch concierge experiences for Parslet runs."""
+
+    def __init__(self, dag: DAG, oracle: ContextOracle) -> None:
+        self._dag = dag
+        self._oracle = oracle
+
+    # ------------------------------------------------------------------
+    # rendering helpers
+    # ------------------------------------------------------------------
+    def render_prologue(self) -> str:
+        """Return a pre-flight briefing describing contexts and tasks."""
+
+        lines: list[str] = []
+        lines.append("╔═══════════════════════════════════════════════╗")
+        lines.append("║   Parslet Concierge • Pre-flight Briefing    ║")
+        lines.append("╚═══════════════════════════════════════════════╝")
+        lines.append("")
+
+        snapshot = self._oracle.snapshot()
+        if snapshot:
+            lines.append("Active Context Palette:")
+            for name, state in snapshot.items():
+                indicator = "✔" if state else "✘"
+                lines.append(f"  {indicator} {name}")
+        else:
+            lines.append("No live detectors registered. All context decisions rely on manual overrides.")
+
+        gated = self._task_context_rows()
+        if gated:
+            lines.append("")
+            lines.append("Context-gated Tasks:")
+            for title, status, detail in gated:
+                lines.append(f"  {status} {title} {detail}")
+        else:
+            lines.append("")
+            lines.append("All tasks are free to run without contextual gating.")
+
+        lines.append("")
+        lines.append(
+            f"Luxury itinerary prepared for {len(self._dag.tasks)} tasks across "
+            f"{self._dag.graph.number_of_edges()} dependencies."
+        )
+        return "\n".join(lines)
+
+    def render_epilogue(self, summary: ConciergeSummary) -> str:
+        """Return a closing report summarising execution."""
+
+        lines: list[str] = []
+        lines.append("")
+        lines.append("╔═══════════════════════════════════════════════╗")
+        lines.append("║    Parslet Concierge • Post-flight Ledger    ║")
+        lines.append("╚═══════════════════════════════════════════════╝")
+        lines.append("")
+        lines.append(
+            f"Tasks • total {summary.total_tasks} | success {summary.completed} | "
+            f"deferred {summary.deferred} | skipped {summary.skipped} | failed {summary.failed}"
+        )
+        lines.append(f"Runtime • {summary.total_runtime:.2f}s shimmering wall-clock")
+        if summary.slowest_task:
+            lines.append(
+                f"Signature moment • {summary.slowest_task} took {summary.slowest_duration:.2f}s"
+            )
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # runbook utilities
+    # ------------------------------------------------------------------
+    def build_runbook(self, runner: "RunnerProtocol" | None = None) -> dict:
+        """Return a JSON-serialisable structure describing the run."""
+
+        tasks = []
+        for task_id, future in self._dag.tasks.items():
+            contexts = list(getattr(future, "contexts", []))
+            eval_result: Iterable[ContextResult] = ()
+            if contexts:
+                _, eval_result = self._oracle.evaluate(contexts)
+            tasks.append(
+                {
+                    "task_id": task_id,
+                    "name": future.func.__name__,
+                    "contexts": contexts,
+                    "energy_cost": future.energy_cost,
+                    "qos": future.qos,
+                    "context_evaluation": [r.__dict__ for r in eval_result],
+                }
+            )
+
+        runbook: dict[str, object] = {
+            "contexts": self._oracle.snapshot(),
+            "tasks": tasks,
+        }
+
+        if runner is not None:
+            runbook["status"] = dict(runner.task_statuses)
+            runbook["timings"] = {k: float(v) for k, v in runner.task_execution_times.items()}
+        return runbook
+
+    def write_runbook(self, path: str | Path, runner: "RunnerProtocol" | None = None) -> None:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as fh:
+            json.dump(self.build_runbook(runner=runner), fh, indent=2)
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _task_context_rows(self) -> list[tuple[str, str, str]]:
+        rows: list[tuple[str, str, str]] = []
+        for task_id, future in sorted(self._dag.tasks.items()):
+            contexts = list(getattr(future, "contexts", []))
+            if not contexts:
+                continue
+            allowed, results = self._oracle.evaluate(contexts)
+            status_icon = "✔" if allowed else "⏸"
+            detail = ", ".join(
+                f"{res.requirement}{'' if res.satisfied else '✘'}" for res in results
+            )
+            rows.append((f"{future.func.__name__} [{task_id}]", status_icon, detail))
+        return rows
+
+    @staticmethod
+    def summarise_runner(runner: "RunnerProtocol") -> ConciergeSummary:
+        counts = Counter(runner.task_statuses.values())
+        total = len(runner.task_statuses)
+        completed = counts.get("SUCCESS", 0)
+        deferred = counts.get("DEFERRED", 0)
+        failed = counts.get("FAILED", 0)
+        skipped = counts.get("SKIPPED", 0)
+        durations = runner.task_execution_times
+        total_runtime = sum(durations.values())
+        slowest_task: str | None = None
+        slowest_duration: float | None = None
+        if durations:
+            slowest_task, slowest_duration = max(durations.items(), key=lambda item: item[1])
+        return ConciergeSummary(
+            total_tasks=total,
+            completed=completed,
+            deferred=deferred,
+            failed=failed,
+            skipped=skipped,
+            total_runtime=total_runtime,
+            slowest_task=slowest_task,
+            slowest_duration=slowest_duration,
+        )
+
+
+class RunnerProtocol:
+    """Small protocol subset of :class:`parslet.core.runner.DAGRunner`."""
+
+    task_statuses: dict[str, str]
+    task_execution_times: dict[str, float]
+
+
+__all__ = ["ConciergeOrchestrator", "ConciergeSummary"]
+

--- a/parslet/core/context.py
+++ b/parslet/core/context.py
@@ -1,0 +1,204 @@
+"""Context orchestration primitives for Parslet.
+
+The :class:`ContextOracle` is a small, battery-friendly decision engine that
+helps Parslet decide if a task should be allowed to execute. Tasks can declare
+context guards via ``@parslet_task(contexts=[...])`` and the oracle evaluates
+those declarations against live system conditions and user supplied overrides.
+
+The goal is to provide a declarative alternative to the rule builders that
+mobile automation suites expose while keeping the implementation lightweight
+enough to run happily on single board computers and Android devices.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import os
+import re
+from typing import Callable, Iterable, Sequence
+
+from ..utils.network_utils import is_network_available, is_vpn_active
+from ..utils.power import get_power_state
+from ..utils.resource_utils import get_battery_level
+
+
+@dataclass(slots=True)
+class ContextResult:
+    """Structured result describing a context evaluation."""
+
+    requirement: str
+    satisfied: bool
+    actual: bool
+    origin: str
+    detail: str | None = None
+
+
+class ContextOracle:
+    """Evaluate declarative context requirements for Parslet tasks.
+
+    Parameters
+    ----------
+    enabled : Iterable[str] | None, optional
+        Manual context tags that should be forced to ``True``. This mirrors the
+        behaviour of toggling scenes in phone automation apps. Users can supply
+        these via CLI flags or the ``PARSLET_CONTEXTS`` environment variable.
+    """
+
+    def __init__(self, enabled: Iterable[str] | None = None) -> None:
+        env_contexts = os.getenv("PARSLET_CONTEXTS", "")
+        env_values = [c.strip() for c in env_contexts.split(",") if c.strip()]
+        manual = list(enabled or []) + env_values
+        self._manual_overrides: set[str] = {self._normalise_name(c) for c in manual}
+        self._detectors: dict[str, Callable[[], bool]] = {}
+        self._aliases: dict[str, str] = {
+            "online": "network.online",
+            "offline": "network.offline",
+            "wifi": "network.online",
+            "vpn": "security.vpn",
+            "plugged": "power.ac",
+        }
+        self._register_builtin_detectors()
+
+    # ------------------------------------------------------------------
+    # public API
+    # ------------------------------------------------------------------
+    def register_detector(self, name: str, detector: Callable[[], bool]) -> None:
+        """Register a custom boolean detector."""
+
+        self._detectors[self._normalise_name(name)] = detector
+
+    def enable(self, name: str) -> None:
+        """Manually enable a context tag for the lifetime of the oracle."""
+
+        self._manual_overrides.add(self._normalise_name(name))
+
+    def evaluate(self, requirements: Sequence[str]) -> tuple[bool, list[ContextResult]]:
+        """Return ``True`` if *all* requirements are satisfied."""
+
+        results: list[ContextResult] = []
+        allow = True
+        for requirement in requirements:
+            result = self._evaluate_single(requirement)
+            results.append(result)
+            if not result.satisfied:
+                allow = False
+        return allow, results
+
+    def snapshot(self) -> dict[str, bool]:
+        """Return the current view of all known detectors and overrides."""
+
+        state: dict[str, bool] = {}
+        for name, detector in self._detectors.items():
+            try:
+                state[name] = bool(detector())
+            except Exception:
+                state[name] = False
+        for manual in self._manual_overrides:
+            state[manual] = True
+        return dict(sorted(state.items()))
+
+    def available_contexts(self) -> list[str]:
+        """Return a sorted list of known context names."""
+
+        names = set(self._detectors) | set(self._manual_overrides)
+        names.update(self._aliases.keys())
+        return sorted(names)
+
+    # ------------------------------------------------------------------
+    # internals
+    # ------------------------------------------------------------------
+    def _register_builtin_detectors(self) -> None:
+        self._detectors["network.online"] = is_network_available
+        self._detectors["network.offline"] = lambda: not is_network_available()
+        self._detectors["security.vpn"] = is_vpn_active
+        self._detectors["power.ac"] = lambda: get_power_state().source == "ac"
+        self._detectors["power.battery"] = lambda: get_power_state().source == "battery"
+        self._detectors["time.night"] = self._is_night
+        self._detectors["time.day"] = lambda: not self._is_night()
+        self._detectors["time.weekend"] = lambda: datetime.now().weekday() >= 5
+        self._detectors["time.office_hours"] = lambda: 9 <= datetime.now().hour < 18
+
+    def _is_night(self) -> bool:
+        hour = datetime.now().hour
+        return hour < 7 or hour >= 22
+
+    def _evaluate_single(self, requirement: str) -> ContextResult:
+        negate = requirement.startswith("!")
+        name = requirement[1:] if negate else requirement
+        normalised = self._normalise_name(name)
+
+        value, origin, detail = self._resolve_context(normalised)
+        actual = bool(value)
+        satisfied = not actual if negate else actual
+
+        # Provide a friendly detail for negated contexts.
+        if negate and detail is None:
+            detail = "negated requirement"
+
+        if value is None:
+            actual = False
+            satisfied = False if not negate else True
+            origin = "unknown"
+            detail = detail or "no detector registered"
+
+        return ContextResult(
+            requirement=requirement,
+            satisfied=satisfied,
+            actual=actual,
+            origin=origin,
+            detail=detail,
+        )
+
+    def _resolve_context(self, name: str) -> tuple[bool | None, str, str | None]:
+        if name in self._manual_overrides:
+            return True, "manual", "enabled by override"
+
+        detector = self._detectors.get(name)
+        if detector:
+            try:
+                return bool(detector()), "detector", None
+            except Exception as exc:  # pragma: no cover - defensive
+                return False, "detector", f"detector error: {exc}"
+
+        dyn_value = self._resolve_dynamic(name)
+        if dyn_value is not None:
+            return dyn_value
+
+        alias = self._aliases.get(name)
+        if alias:
+            return self._resolve_context(alias)
+
+        return None, "unknown", None
+
+    def _resolve_dynamic(self, name: str) -> tuple[bool, str, str | None] | None:
+        battery_match = re.fullmatch(r"battery>=(\d{1,3})", name)
+        if battery_match:
+            threshold = int(battery_match.group(1))
+            level = get_battery_level()
+            if level is None:
+                return False, "battery", "battery level unavailable"
+            detail = f"battery at {level}%"
+            return (level >= threshold, "battery", detail)
+
+        if name == "battery.comfort":
+            level = get_battery_level()
+            if level is None:
+                return False, "battery", "battery level unavailable"
+            return (level >= 60, "battery", f"battery at {level}%")
+
+        if name == "battery.survival":
+            level = get_battery_level()
+            if level is None:
+                return False, "battery", "battery level unavailable"
+            return (level >= 15, "battery", f"battery at {level}%")
+
+        return None
+
+    @staticmethod
+    def _normalise_name(name: str) -> str:
+        return name.strip().lower()
+
+
+__all__ = ["ContextOracle", "ContextResult"]
+

--- a/parslet/core/runner.py
+++ b/parslet/core/runner.py
@@ -30,6 +30,7 @@ from ..utils.resource_utils import (
     probe_resources,
 )
 from .cache import compute_cache_key, load_from_cache, save_to_cache
+from .context import ContextOracle, ContextResult
 from .dag import DAG, DAGCycleError
 from .policy import AdaptivePolicy
 from .scheduler import AdaptiveScheduler
@@ -40,6 +41,7 @@ __all__ = [
     "UpstreamTaskFailedError",
     "BatteryLevelLowError",
     "ResourceLimitError",
+    "ContextNotSatisfiedError",
 ]
 
 
@@ -100,6 +102,26 @@ class ResourceLimitError(RuntimeError):
     """Task failed due to system resource exhaustion (e.g., memory)."""
 
 
+class ContextNotSatisfiedError(RuntimeError):
+    """Task skipped because its context requirements were not satisfied."""
+
+    def __init__(
+        self,
+        task_id: str,
+        task_name: str,
+        results: list[ContextResult],
+    ) -> None:
+        self.task_id = task_id
+        self.task_name = task_name
+        self.results = results
+        detail = ", ".join(
+            f"{r.requirement}{'' if r.satisfied else '✘'}" for r in results
+        )
+        super().__init__(
+            f"Task '{task_id}' ({task_name}) deferred due to context requirements: {detail}."
+        )
+
+
 class DAGRunner:
     """
     Executes tasks defined in a Parslet DAG in the correct topological order.
@@ -126,6 +148,7 @@ class DAGRunner:
         signature_file: str | None = None,
         watch_files: list[str] | None = None,
         disable_cache: bool = False,
+        context_oracle: ContextOracle | None = None,
     ) -> None:
         """
         Initializes the DAGRunner.
@@ -154,6 +177,9 @@ class DAGRunner:
             disable_cache (bool): If True, disables task caching even for tasks
                 that request it. Can also be set via the ``PARSLET_NO_CACHE``
                 environment variable.
+            context_oracle (Optional[ContextOracle]): Oracle used to evaluate
+                declarative context requirements supplied by tasks. If ``None``
+                a default oracle with built-in detectors is created.
         """
         if runner_logger:
             self.logger = runner_logger
@@ -198,6 +224,7 @@ class DAGRunner:
             self.policy = AdaptivePolicy(max_workers=user_specified_max_workers)
 
         self.scheduler = AdaptiveScheduler(policy=self.policy)
+        self.context_oracle = context_oracle or ContextOracle()
         self.max_workers = self.scheduler.calculate_worker_count()
         self.logger.info(f"DAGRunner initialized with max_workers={self.max_workers}")
 
@@ -686,6 +713,33 @@ class DAGRunner:
                         self.task_execution_times[task_id] = 0.0
                         if self.checkpoint:
                             self.checkpoint.mark_complete(task_id, "SUCCESS")
+                        continue
+
+                # Evaluate declarative context requirements.
+                contexts = getattr(current_parslet_future, "contexts", [])
+                if contexts:
+                    allow, results = self.context_oracle.evaluate(contexts)
+                    if not allow:
+                        detail = ", ".join(
+                            f"{r.requirement}{'' if r.satisfied else '✘'}"
+                            for r in results
+                        )
+                        self.logger.info(
+                            "Deferring task '%s' due to context requirements: %s",
+                            task_id,
+                            detail,
+                        )
+                        current_parslet_future.set_exception(
+                            ContextNotSatisfiedError(
+                                task_id,
+                                current_parslet_future.func.__name__,
+                                list(results),
+                            )
+                        )
+                        self.task_statuses[task_id] = "DEFERRED"
+                        self.task_execution_times[task_id] = 0.0
+                        if self.checkpoint:
+                            self.checkpoint.mark_complete(task_id, "DEFERRED")
                         continue
 
                 # Check battery level for battery-sensitive tasks.

--- a/parslet/core/task.py
+++ b/parslet/core/task.py
@@ -90,6 +90,9 @@ class ParsletFuture:
         self.qos: str = getattr(func, "_parslet_qos", "standard")
         self.degradable: bool = getattr(func, "_parslet_degradable", True)
         self.variant_key: str | None = getattr(func, "_parslet_variant_key", None)
+        self.contexts: list[str] = list(
+            getattr(func, "_parslet_contexts", []) or []
+        )
 
         # Internal attributes to store the outcome of the task execution.
         self._result: Any = _RESULT_NOT_SET
@@ -222,6 +225,7 @@ def parslet_task(
     deadline_s: int | None = None,
     qos: str = "standard",
     degradable: bool = True,
+    contexts: list[str] | None = None,
 ) -> Callable[..., ParsletFuture]:
     """
     Decorator to define a Python function as a Parslet task.
@@ -264,6 +268,12 @@ def parslet_task(
             :func:`parslet.security.shell_guard`.
         allow_redefine (bool): Permit replacing an existing task with the same
             name without raising an error.
+        contexts (Optional[List[str]]): Declarative context gates that must be
+            satisfied before the task is allowed to execute. Each entry can be
+            a named detector such as ``"network.online"`` or expressions like
+            ``"battery>=60"``. Prefix a name with ``!`` to require that the
+            context is inactive. See :mod:`parslet.core.context` for the
+            built-in detectors and CLI integration.
 
     Returns:
         Callable: A wrapped function that, when called, returns a
@@ -306,6 +316,7 @@ def parslet_task(
         func_to_wrap._parslet_deadline_s = deadline_s
         func_to_wrap._parslet_qos = qos
         func_to_wrap._parslet_degradable = degradable
+        func_to_wrap._parslet_contexts = list(contexts or [])
 
         @functools.wraps(func_to_wrap)
         def wrapper(*args: object, **kwargs: object) -> ParsletFuture:
@@ -348,6 +359,7 @@ def parslet_task(
         wrapper._parslet_deadline_s = deadline_s
         wrapper._parslet_qos = qos
         wrapper._parslet_degradable = degradable
+        wrapper._parslet_contexts = list(contexts or [])
 
         return wrapper
 

--- a/parslet/main_cli.py
+++ b/parslet/main_cli.py
@@ -88,6 +88,24 @@ def cli() -> None:
         metavar="PATH",
         help="Write task execution stats to the given JSON file",
     )
+    run_p.add_argument(
+        "--context",
+        action="append",
+        default=[],
+        metavar="NAME",
+        help="Force-enable a context tag (can be passed multiple times)",
+    )
+    run_p.add_argument(
+        "--concierge",
+        action="store_true",
+        help="Activate the Parslet Concierge briefing and ledger",
+    )
+    run_p.add_argument(
+        "--concierge-runbook",
+        type=str,
+        metavar="PATH",
+        help="Write the concierge runbook JSON to PATH",
+    )
 
     rad_p = sub.add_parser("rad", help="Run RAD by Parslet example")
     rad_p.add_argument("image", nargs="?")
@@ -122,7 +140,12 @@ def cli() -> None:
             from rich.table import Table
 
             from parslet.cli import load_workflow_module
-            from parslet.core import DAG, DAGRunner
+            from parslet.core import (
+                ConciergeOrchestrator,
+                ContextOracle,
+                DAG,
+                DAGRunner,
+            )
             from parslet.core.policy import AdaptivePolicy
             from parslet.security.defcon import Defcon
 
@@ -135,6 +158,11 @@ def cli() -> None:
             futures = mod.main()
             dag = DAG()
             dag.build_dag(futures)
+
+            context_oracle = ContextOracle(args.context or None)
+            concierge = None
+            if args.concierge or args.concierge_runbook:
+                concierge = ConciergeOrchestrator(dag, context_oracle)
 
             if getattr(mod, "__converted_from_parsl__", False):
                 from parslet.compat.parsl_adapter import export_parsl_dag
@@ -170,6 +198,7 @@ def cli() -> None:
                 disable_cache=args.no_cache,
                 json_logs=args.json_logs,
                 max_workers=args.max_workers,
+                context_oracle=context_oracle,
             )
 
             if args.simulate:
@@ -183,7 +212,13 @@ def cli() -> None:
                     print(f"Available RAM: {ram:.1f} MB")
                 if batt is not None:
                     print(f"Battery level: {batt}%")
+                if concierge is not None:
+                    print("")
+                    print(concierge.render_prologue())
                 return
+
+            if concierge is not None:
+                print(concierge.render_prologue())
 
             if args.monitor:
 
@@ -212,6 +247,17 @@ def cli() -> None:
             else:
                 with offline_guard(args.offline):
                     runner.run(dag)
+                if concierge is not None:
+                    summary = ConciergeOrchestrator.summarise_runner(runner)
+                    if args.concierge:
+                        print(concierge.render_epilogue(summary))
+                    if args.concierge_runbook:
+                        concierge.write_runbook(args.concierge_runbook, runner)
+                        logger.info(
+                            "Concierge runbook written to %s",
+                            args.concierge_runbook,
+                        )
+
                 if args.export_stats:
                     try:
                         stats_path = args.export_stats

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "parslet"
-version = "0.6.0"
+version = "0.6.1"
 description = "Simplify Python workflows with a minimal DAG engine."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_context_oracle.py
+++ b/tests/test_context_oracle.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+
+from parslet.core import ContextOracle, DAG, DAGRunner, parslet_task
+from parslet.core.runner import ContextNotSatisfiedError
+
+
+def test_context_oracle_manual_enable() -> None:
+    oracle = ContextOracle(["studio"])
+    allowed, results = oracle.evaluate(["studio"])
+    assert allowed
+    assert results[0].origin == "manual"
+
+
+def test_context_oracle_battery_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("parslet.core.context.get_battery_level", lambda: 82)
+    oracle = ContextOracle()
+    allowed, _ = oracle.evaluate(["battery>=60"])
+    assert allowed
+
+    monkeypatch.setattr("parslet.core.context.get_battery_level", lambda: 18)
+    allowed, details = oracle.evaluate(["battery>=60"])
+    assert not allowed
+    assert details[0].origin == "battery"
+
+
+def test_runner_defers_and_honours_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    executions: list[str] = []
+
+    @parslet_task(name="concierge_task", contexts=["atelier"], allow_redefine=True)
+    def gated_task() -> str:
+        executions.append("ran")
+        return "opulent"
+
+    # Without context the task should be deferred.
+    dag = DAG()
+    fut = gated_task()
+    dag.build_dag([fut])
+    runner = DAGRunner(context_oracle=ContextOracle())
+    runner.run(dag)
+    assert runner.task_statuses[fut.task_id] == "DEFERRED"
+    with pytest.raises(ContextNotSatisfiedError):
+        fut.result()
+    assert executions == []
+
+    # When the context is enabled manually the task should execute.
+    dag_ok = DAG()
+    fut_ok = gated_task()
+    dag_ok.build_dag([fut_ok])
+    runner_ok = DAGRunner(context_oracle=ContextOracle(["atelier"]))
+    runner_ok.run(dag_ok)
+    assert runner_ok.task_statuses[fut_ok.task_id] == "SUCCESS"
+    assert executions == ["ran"]


### PR DESCRIPTION
## Summary
- introduce ContextOracle-powered context scenes for tasks and skip handling in the runner
- add a concierge orchestrator with CLI options and runbook generation for luxury workflows
- update documentation and bump Parslet to v0.6.1 to showcase the new concierge experience

## Testing
- pytest tests/test_context_oracle.py

------
https://chatgpt.com/codex/tasks/task_e_68e5052e1b448333bcf5ea4c56306b66