### PR TITLE
Add adaptive battery-aware execution mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Reworked ``--battery-mode`` into a live battery-aware execution policy with
+  normal, low, and critical power bands.
+- Added configurable ``--battery-low`` and ``--battery-critical`` thresholds.
+- Added energy/QoS-aware deferral while preserving urgent and non-degradable
+  tasks, unrestricted AC operation, and safe behaviour when telemetry is
+  unavailable.
+
 ## v0.6.1 - 2025-10-07
 - Added ContextOracle scenes and `contexts` task metadata with CLI integration.
 - Introduced Concierge orchestrator with pre-flight briefings and JSON runbooks.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ parslet run my_package.workflow:main --max-workers 4 --json-logs --export-stats 
 Parslet is small, but it's packed with neat features for real-world use.
 
 -   **Works Offline:** Your automated workflows run even without an internet connection. See the [examples](docs/examples.md).
--   **Saves Battery:** Use the special `--battery-mode` to tell Parslet to take it easy and conserve power. Read about [battery mode](docs/source/battery_mode.rst).
+-   **Rations Power Intelligently:** `--battery-mode` monitors changing power conditions, reduces local concurrency, and defers optional expensive work while preserving urgent tasks. Charging and unsupported devices remain unrestricted. Read about [battery mode](docs/source/battery_mode.rst).
 -   **Smart About Resources:** It automatically checks your device's CPU and memory to run smoothly without crashing. The [AdaptivePolicy](docs/policy.md) adjusts workers on the fly.
 -   **DEFCON:** Parslet's built-in safety layer. It prevents tasks from calling shell commands or accessing the network in ways you did not explicitly allow, so a buggy or malicious task cannot damage your device or leak data. Use `@parslet_task(allow_shell=True)` only when needed. Learn more in the [security notes](docs/technical-overview.md).
 -   **Plays Well with Others:** If you ever move to a big server, Parslet has tools to convert your recipes to run on powerful systems like Parsl or Dask. See [compatibility](docs/compatibility.md).

--- a/docs/source/battery_mode.rst
+++ b/docs/source/battery_mode.rst
@@ -6,9 +6,36 @@ We've all been there. You're in the middle of something important, and you see t
 How Does It Work?
 -----------------
 
-When you tell Parslet to run in battery-saver mode, an :class:`AdaptivePolicy` kicks in. It looks at your device's CPU, available memory, and most importantly, your current battery percentage.
+Battery mode samples the device throughout a run rather than making a single
+decision at startup. Its default power bands are:
 
-Based on what it sees, the policy decides how many worker threads to keep alive. If the battery drops below about 40%, the pool is automatically cut in half; when the battery recovers, it can grow again up to its cap. Often, it will slow down to running just one task at a time. This is like putting your phone into "Low Power Mode"—it helps your battery last as long as possible so you can finish your work.
+.. list-table::
+   :header-rows: 1
+
+   * - Power state
+     - Worker ceiling
+     - Task behaviour
+   * - Charging or AC power
+     - Normal
+     - Run normally
+   * - Above 40%
+     - Normal
+     - Run normally
+   * - 16% to 40%
+     - Half
+     - Defer high-energy, best-effort tasks
+   * - 15% or below
+     - One
+     - Run light, urgent, or non-degradable work; defer optional expensive work
+   * - Battery unavailable
+     - Normal
+     - Run normally
+
+The last rule is important on desktops, servers, and devices that do not
+provide battery telemetry: missing information never causes Parslet to slow
+down unexpectedly. If the device is connected to power, even a very low
+battery percentage is treated as charging and the normal worker limit is
+restored.
 
 How Do I Turn It On?
 --------------------
@@ -19,6 +46,31 @@ It's super easy! Just add the ``--battery-mode`` flag when you run your recipe f
 
    parslet run my_recipe.py --battery-mode
 
+You can customize the thresholds:
+
+.. code-block:: bash
+
+   parslet run my_recipe.py --battery-mode --battery-low 35 --battery-critical 10
+
+Describe task importance with the existing energy and quality-of-service
+metadata:
+
+.. code-block:: python
+
+   from parslet import parslet_task
+
+   @parslet_task(energy_cost="high", qos="best_effort")
+   def generate_previews():
+       ...
+
+   @parslet_task(energy_cost="high", qos="high")
+   def upload_emergency_record():
+       ...
+
+The preview task may be deferred as the battery falls. The high-priority
+upload remains eligible to run. Set ``degradable=False`` for work that must
+not be deferred automatically.
+
 What if I Still Need to Go a Little Faster?
 -------------------------------------------
 
@@ -28,6 +80,11 @@ You're still in control! If you want to use battery-saver mode but still want to
 
    parslet run my_recipe.py --battery-mode --max-workers 2
 
-Battery mode doesn't turn off any of Parslet's other cool features. You can still save your progress with checkpointing, get pictures of your workflow, and see all the logs. It just tells Parslet to be a little more gentle on your device.
+``--force-battery`` bypasses both battery-sensitive task checks and battery
+mode rationing. Battery mode does not pause arbitrary work that is already
+running; it controls worker concurrency and whether new tasks may start.
+
+Battery mode doesn't turn off any of Parslet's other features. You can still
+save progress with checkpointing, visualize the workflow, and inspect logs.
 
 To see all the other commands you can use, check out our guide to the :doc:`cli` (the "remote control").

--- a/parslet/__init__.py
+++ b/parslet/__init__.py
@@ -6,6 +6,7 @@ interface compact and easy to learn.  Everything else remains available under
 """
 
 from .core import (
+    BatteryAwarePolicy,
     ConciergeOrchestrator,
     ContextOracle,
     DAG,
@@ -36,6 +37,7 @@ __all__ = [
     "DAGRunner",
     "task_variant",
     "EnergyAwarePolicy",
+    "BatteryAwarePolicy",
     "PowerState",
     "get_power_state",
     "watch",

--- a/parslet/core/__init__.py
+++ b/parslet/core/__init__.py
@@ -15,7 +15,12 @@ from .parsl_bridge import (
     execute_with_parsl,
     parsl_python,
 )
-from .policy import AdaptivePolicy, EnergyAwarePolicy  # noqa: F401
+from .policy import (  # noqa: F401
+    AdaptivePolicy,
+    BatteryAwarePolicy,
+    BatteryDecision,
+    EnergyAwarePolicy,
+)
 from .runner import (
     BatteryLevelLowError,
     DAGRunner,  # noqa: F401
@@ -45,6 +50,8 @@ __all__ = [
     "UpstreamTaskFailedError",
     "AdaptivePolicy",
     "EnergyAwarePolicy",
+    "BatteryAwarePolicy",
+    "BatteryDecision",
     "AdaptiveScheduler",
     "ContextOracle",
     "ContextResult",

--- a/parslet/core/policy.py
+++ b/parslet/core/policy.py
@@ -1,6 +1,7 @@
 """Resource-aware worker pool policy."""
 
 from dataclasses import dataclass
+from typing import Literal
 
 from ..utils.power import PowerState
 from ..utils.resource_utils import ResourceSnapshot
@@ -70,3 +71,80 @@ class EnergyAwarePolicy:
             if power.percent < self.low_battery_threshold:
                 return max(1, current // 2)
         return current
+
+
+BatteryBand = Literal["ac", "normal", "low", "critical", "unknown"]
+
+
+@dataclass(frozen=True)
+class BatteryDecision:
+    """A battery policy decision for one task."""
+
+    run: bool
+    band: BatteryBand
+    reason: str | None = None
+
+
+@dataclass
+class BatteryAwarePolicy(EnergyAwarePolicy):
+    """Ration local work while preserving urgent tasks.
+
+    Unknown telemetry and AC power are deliberately non-restrictive.  This
+    prevents unsupported desktops and servers from being slowed down merely
+    because they do not expose a battery sensor.
+    """
+
+    critical_battery_threshold: int = 15
+
+    def __post_init__(self) -> None:
+        if not 0 <= self.critical_battery_threshold < self.low_battery_threshold <= 100:
+            raise ValueError(
+                "battery thresholds must satisfy 0 <= critical < low <= 100"
+            )
+
+    def band(self, power: PowerState) -> BatteryBand:
+        if power.source == "ac" or power.is_charging is True:
+            return "ac"
+        if power.source == "unknown" or power.percent is None:
+            return "unknown"
+        if power.percent <= self.critical_battery_threshold:
+            return "critical"
+        if power.percent <= self.low_battery_threshold:
+            return "low"
+        return "normal"
+
+    def decide_max_workers(self, power: PowerState, current: int) -> int:
+        """Return a concurrency ceiling for the current power band."""
+
+        band = self.band(power)
+        if band == "critical":
+            return 1
+        if band == "low":
+            return max(1, current // 2)
+        return max(1, current)
+
+    def decide_task(self, fut: ParsletFuture, power: PowerState) -> BatteryDecision:
+        """Decide whether a task should start under current power conditions."""
+
+        band = self.band(power)
+        if band not in {"low", "critical"}:
+            return BatteryDecision(True, band)
+
+        # High-QoS work is never deferred automatically.  At low power only
+        # explicitly best-effort, expensive work is held.  Critical power is
+        # stricter, but non-degradable work is still allowed to complete.
+        if fut.qos == "high" or not fut.degradable:
+            return BatteryDecision(True, band)
+        if band == "low" and not (
+            fut.energy_cost == "high" and fut.qos == "best_effort"
+        ):
+            return BatteryDecision(True, band)
+        if band == "critical" and fut.energy_cost == "low":
+            return BatteryDecision(True, band)
+
+        percent = "unknown" if power.percent is None else f"{power.percent}%"
+        reason = (
+            f"{fut.energy_cost}-energy {fut.qos} task deferred at {percent} "
+            f"battery ({band} power band)"
+        )
+        return BatteryDecision(False, band, reason)

--- a/parslet/core/runner.py
+++ b/parslet/core/runner.py
@@ -24,6 +24,7 @@ from parslet.security.defcon import Defcon
 from ..utils.checkpointing import CheckpointManager
 from ..utils.diagnostics import find_free_port
 from ..utils.network_utils import is_network_available, is_vpn_active
+from ..utils.power import get_power_state
 from ..utils.resource_utils import (
     get_available_ram_mb,
     get_battery_level,
@@ -32,7 +33,7 @@ from ..utils.resource_utils import (
 from .cache import compute_cache_key, load_from_cache, save_to_cache
 from .context import ContextOracle, ContextResult
 from .dag import DAG, DAGCycleError
-from .policy import AdaptivePolicy
+from .policy import AdaptivePolicy, BatteryAwarePolicy
 from .scheduler import AdaptiveScheduler
 from .task import ParsletFuture
 
@@ -40,6 +41,7 @@ __all__ = [
     "DAGRunner",
     "UpstreamTaskFailedError",
     "BatteryLevelLowError",
+    "BatteryPolicyDeferredError",
     "ResourceLimitError",
     "ContextNotSatisfiedError",
 ]
@@ -98,6 +100,16 @@ class BatteryLevelLowError(RuntimeError):
         )
 
 
+class BatteryPolicyDeferredError(RuntimeError):
+    """Task deferred by the opt-in battery-aware execution policy."""
+
+    def __init__(self, task_id: str, task_name: str, reason: str) -> None:
+        self.task_id = task_id
+        self.task_name = task_name
+        self.reason = reason
+        super().__init__(f"Task '{task_id}' ({task_name}) deferred: {reason}.")
+
+
 class ResourceLimitError(RuntimeError):
     """Task failed due to system resource exhaustion (e.g., memory)."""
 
@@ -118,7 +130,8 @@ class ContextNotSatisfiedError(RuntimeError):
             f"{r.requirement}{'' if r.satisfied else '✘'}" for r in results
         )
         super().__init__(
-            f"Task '{task_id}' ({task_name}) deferred due to context requirements: {detail}."
+            f"Task '{task_id}' ({task_name}) deferred due to context "
+            f"requirements: {detail}."
         )
 
 
@@ -149,6 +162,8 @@ class DAGRunner:
         watch_files: list[str] | None = None,
         disable_cache: bool = False,
         context_oracle: ContextOracle | None = None,
+        battery_mode: bool = False,
+        battery_policy: BatteryAwarePolicy | None = None,
     ) -> None:
         """
         Initializes the DAGRunner.
@@ -180,6 +195,10 @@ class DAGRunner:
             context_oracle (Optional[ContextOracle]): Oracle used to evaluate
                 declarative context requirements supplied by tasks. If ``None``
                 a default oracle with built-in detectors is created.
+            battery_mode (bool): Enable live battery-aware concurrency and
+                task-admission decisions.
+            battery_policy (Optional[BatteryAwarePolicy]): Thresholds and
+                task-admission rules used when battery mode is enabled.
         """
         if runner_logger:
             self.logger = runner_logger
@@ -205,6 +224,8 @@ class DAGRunner:
                     )
 
         self.ignore_battery = ignore_battery
+        self.battery_mode = battery_mode
+        self.battery_policy = battery_policy or BatteryAwarePolicy()
         self.failsafe_mode = failsafe_mode
         self.fallback_active = False
         user_specified_max_workers = max_workers
@@ -226,6 +247,11 @@ class DAGRunner:
         self.scheduler = AdaptiveScheduler(policy=self.policy)
         self.context_oracle = context_oracle or ContextOracle()
         self.max_workers = self.scheduler.calculate_worker_count()
+        self._battery_worker_capacity = self.max_workers
+        if self.battery_mode and not self.ignore_battery:
+            self.max_workers = self.battery_policy.decide_max_workers(
+                get_power_state(), self._battery_worker_capacity
+            )
         self.logger.info(f"DAGRunner initialized with max_workers={self.max_workers}")
 
         # Determine monitoring port, fallback if busy
@@ -397,6 +423,10 @@ class DAGRunner:
             return
         snapshot = probe_resources()
         new_size = self.policy.decide_pool_size(snapshot)
+        if self.battery_mode and not self.ignore_battery:
+            new_size = self.battery_policy.decide_max_workers(
+                get_power_state(), new_size
+            )
         old_size = getattr(self, "_pool_size", new_size)
         if new_size != old_size:
             self.executor._max_workers = new_size
@@ -789,6 +819,40 @@ class DAGRunner:
                     if self.checkpoint:
                         self.checkpoint.mark_complete(task_id, "SKIPPED")
                     continue
+
+                # In opt-in battery mode, refresh telemetry before every task
+                # so a long workflow responds when power conditions change.
+                if self.battery_mode and not self.ignore_battery:
+                    power = get_power_state()
+                    desired_workers = self.battery_policy.decide_max_workers(
+                        power, self._battery_worker_capacity
+                    )
+                    if desired_workers != getattr(self, "_pool_size", self.max_workers):
+                        old_workers = self._pool_size
+                        executor._max_workers = desired_workers
+                        self._pool_size = desired_workers
+                        self.logger.info(
+                            "Battery mode adjusted worker ceiling from %s to %s (%s).",
+                            old_workers,
+                            desired_workers,
+                            self.battery_policy.band(power),
+                        )
+                    decision = self.battery_policy.decide_task(
+                        current_parslet_future, power
+                    )
+                    if not decision.run:
+                        reason = decision.reason or "battery policy"
+                        self.logger.warning("Deferring task '%s': %s", task_id, reason)
+                        current_parslet_future.set_exception(
+                            BatteryPolicyDeferredError(
+                                task_id,
+                                current_parslet_future.func.__name__,
+                                reason,
+                            )
+                        )
+                        self.task_statuses[task_id] = "DEFERRED"
+                        self.task_execution_times[task_id] = 0.0
+                        continue
 
                 # All dependencies resolved successfully, submit the task to
                 # the executor.

--- a/parslet/main_cli.py
+++ b/parslet/main_cli.py
@@ -44,7 +44,21 @@ def cli() -> None:
     run_p.add_argument(
         "--battery-mode",
         action="store_true",
-        help="Limit workers when system battery is low",
+        help="Adapt workers and defer optional expensive work as battery falls",
+    )
+    run_p.add_argument(
+        "--battery-low",
+        type=int,
+        default=40,
+        metavar="PERCENT",
+        help="Battery percentage at which conservation begins",
+    )
+    run_p.add_argument(
+        "--battery-critical",
+        type=int,
+        default=15,
+        metavar="PERCENT",
+        help="Battery percentage at which critical conservation begins",
     )
     run_p.add_argument(
         "--force-battery",
@@ -153,12 +167,12 @@ def cli() -> None:
 
             from parslet.cli import load_workflow_module, resolve_workflow_entry
             from parslet.core import (
+                DAG,
                 ConciergeOrchestrator,
                 ContextOracle,
-                DAG,
                 DAGRunner,
             )
-            from parslet.core.policy import AdaptivePolicy
+            from parslet.core.policy import BatteryAwarePolicy
             from parslet.security.defcon import Defcon
 
             wf_input = args.workflow
@@ -180,7 +194,7 @@ def cli() -> None:
             if getattr(mod, "__converted_from_parsl__", False):
                 from parslet.compat.parsl_adapter import export_parsl_dag
 
-                orig = Path(getattr(mod, "__original_parsl_path__"))
+                orig = Path(mod.__original_parsl_path__)
                 export_name = f"{orig.stem}_parslet_export.py"
                 export_path = orig.with_name(export_name)
                 try:
@@ -201,11 +215,11 @@ def cli() -> None:
                     err = f"Failed to export DAG to PNG: {e}"
                     logger.error(err, exc_info=False)
 
-            policy = None
-            if args.battery_mode:
-                policy = AdaptivePolicy(max_workers=2, battery_threshold=40)
+            battery_policy = BatteryAwarePolicy(
+                low_battery_threshold=args.battery_low,
+                critical_battery_threshold=args.battery_critical,
+            )
             runner = DAGRunner(
-                policy=policy,
                 failsafe_mode=args.failsafe_mode,
                 watch_files=[str(wf)] if wf else None,
                 disable_cache=args.no_cache,
@@ -213,6 +227,8 @@ def cli() -> None:
                 max_workers=args.max_workers,
                 context_oracle=context_oracle,
                 ignore_battery=args.force_battery,
+                battery_mode=args.battery_mode,
+                battery_policy=battery_policy,
             )
 
             if args.simulate:
@@ -388,6 +404,7 @@ def cli() -> None:
 
         elif args.cmd == "cache":
             from datetime import datetime
+
             from parslet.core.cache import get_cache_dir
 
             cache_dir = get_cache_dir()
@@ -397,7 +414,9 @@ def cli() -> None:
                     print("Cache is empty.")
                 for f in files:
                     st = f.stat()
-                    ts = datetime.fromtimestamp(st.st_mtime).isoformat(timespec="seconds")
+                    ts = datetime.fromtimestamp(st.st_mtime).isoformat(
+                        timespec="seconds"
+                    )
                     print(f"{f.name}	{st.st_size} bytes	{ts}")
             elif args.cache_cmd == "clear":
                 count = 0

--- a/tests/test_api_surface.py
+++ b/tests/test_api_surface.py
@@ -10,6 +10,7 @@ def test_top_level_public_api() -> None:
         "DAGRunner",
         "task_variant",
         "EnergyAwarePolicy",
+        "BatteryAwarePolicy",
         "PowerState",
         "get_power_state",
         "watch",

--- a/tests/test_battery_aware_mode.py
+++ b/tests/test_battery_aware_mode.py
@@ -1,0 +1,89 @@
+import logging
+from typing import Literal
+
+import pytest
+from _pytest.logging import LogCaptureFixture
+
+from parslet.core import DAG, BatteryAwarePolicy, DAGRunner, parslet_task
+from parslet.core.runner import BatteryPolicyDeferredError
+from parslet.utils.power import PowerState
+
+
+def state(
+    source: Literal["battery", "ac", "unknown"] = "battery",
+    percent: int | None = 50,
+    charging: bool | None = False,
+) -> PowerState:
+    return PowerState(source=source, percent=percent, is_charging=charging)
+
+
+def test_policy_power_bands_and_worker_limits() -> None:
+    policy = BatteryAwarePolicy(low_battery_threshold=40, critical_battery_threshold=15)
+
+    assert policy.band(state(source="ac", percent=5, charging=True)) == "ac"
+    assert policy.band(state(percent=70)) == "normal"
+    assert policy.band(state(percent=40)) == "low"
+    assert policy.band(state(percent=15)) == "critical"
+    assert policy.decide_max_workers(state(percent=40), 8) == 4
+    assert policy.decide_max_workers(state(percent=15), 8) == 1
+    assert policy.decide_max_workers(PowerState(), 8) == 8
+
+
+def test_policy_rejects_invalid_thresholds() -> None:
+    with pytest.raises(ValueError, match="critical < low"):
+        BatteryAwarePolicy(low_battery_threshold=15, critical_battery_threshold=15)
+
+
+def test_low_battery_defers_only_expensive_best_effort_work() -> None:
+    policy = BatteryAwarePolicy()
+
+    @parslet_task(energy_cost="high", qos="best_effort", allow_redefine=True)
+    def optional_render() -> str:
+        return "rendered"
+
+    @parslet_task(energy_cost="high", qos="high", allow_redefine=True)
+    def urgent_upload() -> str:
+        return "uploaded"
+
+    assert not policy.decide_task(optional_render(), state(percent=30)).run
+    assert policy.decide_task(urgent_upload(), state(percent=10)).run
+
+
+def test_critical_battery_runs_light_tasks_and_defers_expensive_tasks(
+    monkeypatch: pytest.MonkeyPatch, caplog: LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(
+        "parslet.core.runner.get_power_state", lambda: state(percent=10)
+    )
+
+    @parslet_task(energy_cost="low", allow_redefine=True)
+    def light_task() -> str:
+        return "done"
+
+    @parslet_task(energy_cost="high", allow_redefine=True)
+    def heavy_task() -> str:
+        return "expensive"
+
+    light = light_task()
+    heavy = heavy_task()
+    dag = DAG()
+    dag.build_dag([light, heavy])
+
+    with caplog.at_level(logging.WARNING):
+        runner = DAGRunner(max_workers=4, battery_mode=True)
+        runner.run(dag)
+
+    assert light.result() == "done"
+    assert isinstance(heavy._exception, BatteryPolicyDeferredError)
+    assert runner.task_statuses[heavy.task_id] == "DEFERRED"
+    assert runner.max_workers == 1
+    assert "critical power band" in caplog.text
+
+
+def test_charging_device_is_not_rationed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "parslet.core.runner.get_power_state",
+        lambda: state(source="ac", percent=10, charging=True),
+    )
+    runner = DAGRunner(max_workers=4, battery_mode=True)
+    assert runner.max_workers == 4


### PR DESCRIPTION
## Summary

Turns Parslet's existing `--battery-mode` flag into a live, energy-aware execution policy.

- samples power state throughout a workflow instead of only at startup
- uses AC, normal, low, critical, and unknown power bands
- halves local concurrency on low battery and limits critical battery to one worker
- defers expensive optional work while preserving high-QoS and non-degradable tasks
- restores normal operation while charging
- remains unrestricted when battery telemetry is unavailable
- adds configurable `--battery-low` and `--battery-critical` thresholds
- composes battery limits with the existing CPU/RAM adaptive policy
- documents task metadata and override behaviour

## Default behaviour

| State | Concurrency | Admission |
|---|---:|---|
| Charging / AC | normal | normal |
| Above 40% | normal | normal |
| 16–40% | half | expensive best-effort work deferred |
| 15% or below | one | light, urgent, and non-degradable work preserved |
| Unknown telemetry | normal | normal |

Battery mode remains opt-in. `--force-battery` bypasses its rationing and existing battery-sensitive checks.

## Verification

- 86 passed, 1 skipped
- critical Ruff checks passed
- Black passed for changed Python files
- Mypy passed for the configured strict target
- package build passed
- Twine validation passed